### PR TITLE
refactor: 일부 lint 규칙 제거

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -33,6 +33,8 @@
     "no-console": "warn",
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-use-before-define": "off",
+    "react/require-default-props": "off",
+    "react/jsx-props-no-spreading": "off",
     "import/extensions": "off"
   }
 }

--- a/frontend/src/components/@common/Button/TextButton.tsx
+++ b/frontend/src/components/@common/Button/TextButton.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable react/require-default-props */
-/* eslint-disable react/jsx-props-no-spreading */
-
 import { styled } from 'styled-components';
 import { BORDER_RADIUS, FONT_SIZE } from '~/styles/common';
 

--- a/frontend/src/components/@common/ProfileImage/ProfileImage.tsx
+++ b/frontend/src/components/@common/ProfileImage/ProfileImage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import { styled } from 'styled-components';
 
 interface ProfileImageProps extends React.HTMLAttributes<HTMLImageElement> {

--- a/frontend/src/components/RestaurantCard/RestaurantCard.tsx
+++ b/frontend/src/components/RestaurantCard/RestaurantCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import { styled } from 'styled-components';
 import Label from '~/components/@common/Label';
 import { BORDER_RADIUS, FONT_SIZE } from '~/styles/common';


### PR DESCRIPTION
다음과 같은 lint 를 off 하였습니다.

### react/require-default-props
- defaultProps를 optional한 값에 꼭 명시해야되는 룰
### react/jsx-props-no-spreading
- props를 spreading 문법으로 표현하지 못하게 하는 룰 (ex. ...props)