### PR TITLE
114 bug storybookreact 가 devdependencies dependencies 둘 다 적혀져있는 오류

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "styled-components": "^6.0.2",
-    "@storybook/react": "^7.0.25"
+    "styled-components": "^6.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",


### PR DESCRIPTION
## ✨ 요약
#114 

__storybook/@react 라이브러리를 devDependencies에 두어서 해결 하였습니다.__

## 😎 해결한 이슈
- close #114

