### PR TITLE
feat: 셀럽 ID와 카테고리, 음식점이름으로 음식점 검색 API 작성

### DIFF
--- a/backend/src/main/java/com/celuveat/celeb/presentation/CelebController.java
+++ b/backend/src/main/java/com/celuveat/celeb/presentation/CelebController.java
@@ -1,0 +1,27 @@
+package com.celuveat.celeb.presentation;
+
+import com.celuveat.celeb.domain.CelebRepository;
+import com.celuveat.celeb.presentation.response.FindAllCelebResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/celebs")
+public class CelebController {
+
+    private final CelebRepository celebRepository;
+
+    @GetMapping
+    ResponseEntity<List<FindAllCelebResponse>> findAll() {
+        List<FindAllCelebResponse> result = celebRepository.findAll()
+                .stream()
+                .map(FindAllCelebResponse::from)
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/com/celuveat/celeb/presentation/response/FindAllCelebResponse.java
+++ b/backend/src/main/java/com/celuveat/celeb/presentation/response/FindAllCelebResponse.java
@@ -1,0 +1,20 @@
+package com.celuveat.celeb.presentation.response;
+
+import com.celuveat.celeb.domain.Celeb;
+
+public record FindAllCelebResponse(
+        Long id,
+        String name,
+        String youtubeChannelName,
+        String profileImageUrl
+) {
+
+    public static FindAllCelebResponse from(Celeb celeb) {
+        return new FindAllCelebResponse(
+                celeb.id(),
+                celeb.name(),
+                celeb.youtubeChannelName(),
+                celeb.profileImageUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/celuveat/common/config/WebConfig.java
+++ b/backend/src/main/java/com/celuveat/common/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.celuveat.common.config;
 
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/celuveat/common/util/DynamicJpqlUtil.java
+++ b/backend/src/main/java/com/celuveat/common/util/DynamicJpqlUtil.java
@@ -1,0 +1,21 @@
+package com.celuveat.common.util;
+
+import java.util.List;
+
+public class DynamicJpqlUtil {
+
+    public static void appendQueryIfTrue(
+            List<String> appendedQuery,
+            boolean condition,
+            String format,
+            Object... param
+    ) {
+        if (condition) {
+            appendedQuery.add(format.formatted(param));
+        }
+    }
+
+    public static boolean notNull(Object t) {
+        return t != null;
+    }
+}

--- a/backend/src/main/java/com/celuveat/common/util/DynamicQueryUtil.java
+++ b/backend/src/main/java/com/celuveat/common/util/DynamicQueryUtil.java
@@ -2,7 +2,7 @@ package com.celuveat.common.util;
 
 import java.util.List;
 
-public class DynamicJpqlUtil {
+public class DynamicQueryUtil {
 
     public static void appendQueryIfTrue(
             List<String> appendedQuery,

--- a/backend/src/main/java/com/celuveat/common/util/StringUtil.java
+++ b/backend/src/main/java/com/celuveat/common/util/StringUtil.java
@@ -1,0 +1,15 @@
+package com.celuveat.common.util;
+
+import java.util.regex.Pattern;
+
+public class StringUtil {
+
+    private static final Pattern REPLACE_ALL_BLANK_PATTERN = Pattern.compile("\\s+");
+
+    public static String replaceAllBlank(String input) {
+        if (input == null) {
+            return null;
+        }
+        return REPLACE_ALL_BLANK_PATTERN.matcher(input.strip()).replaceAll("");
+    }
+}

--- a/backend/src/main/java/com/celuveat/common/util/StringUtil.java
+++ b/backend/src/main/java/com/celuveat/common/util/StringUtil.java
@@ -4,12 +4,12 @@ import java.util.regex.Pattern;
 
 public class StringUtil {
 
-    private static final Pattern REPLACE_ALL_BLANK_PATTERN = Pattern.compile("\\s+");
+    private static final Pattern BLANK_PATTERN = Pattern.compile("\\s+");
 
-    public static String replaceAllBlank(String input) {
+    public static String removeAllBlank(String input) {
         if (input == null) {
             return null;
         }
-        return REPLACE_ALL_BLANK_PATTERN.matcher(input.strip()).replaceAll("");
+        return BLANK_PATTERN.matcher(input.strip()).replaceAll("");
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
@@ -30,15 +30,15 @@ public class RestaurantQueryService {
 
     public List<RestaurantQueryResponse> findAll(RestaurantSearchCond cond) {
         List<Restaurant> restaurants = restaurantQueryRepository.getRestaurants(cond);
-        List<Video> videos = findVideoByRestaurantIdsIn(restaurants);
+        List<Video> videos = findVideoByRestaurantIn(restaurants);
         Map<Restaurant, List<Celeb>> celebs = mapToCeleb(groupingVideoByRestaurant(videos));
-        List<RestaurantImage> images = findImageByRestaurantIdsIn(restaurants);
+        List<RestaurantImage> images = findImageByRestaurantIn(restaurants);
         Map<Restaurant, List<RestaurantImage>> restaurantListMap = groupingImageByRestaurant(images);
         return toResponseList(celebs, restaurantListMap);
     }
 
-    private List<Video> findVideoByRestaurantIdsIn(List<Restaurant> restaurantIds) {
-        return videoRepository.findAllByRestaurantIn(restaurantIds);
+    private List<Video> findVideoByRestaurantIn(List<Restaurant> restaurants) {
+        return videoRepository.findAllByRestaurantIn(restaurants);
     }
 
     private Map<Restaurant, List<Video>> groupingVideoByRestaurant(List<Video> videos) {
@@ -57,8 +57,8 @@ public class RestaurantQueryService {
         return celebs;
     }
 
-    private List<RestaurantImage> findImageByRestaurantIdsIn(List<Restaurant> restaurantIds) {
-        return restaurantImageRepository.findAllByRestaurantIn(restaurantIds);
+    private List<RestaurantImage> findImageByRestaurantIn(List<Restaurant> restaurants) {
+        return restaurantImageRepository.findAllByRestaurantIn(restaurants);
     }
 
     private Map<Restaurant, List<RestaurantImage>> groupingImageByRestaurant(List<RestaurantImage> images) {

--- a/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
@@ -7,6 +7,8 @@ import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
 import com.celuveat.restaurant.domain.Restaurant;
 import com.celuveat.restaurant.domain.RestaurantImage;
 import com.celuveat.restaurant.domain.RestaurantImageRepository;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository.RestaurantSearchCond;
 import com.celuveat.video.domain.Video;
 import com.celuveat.video.domain.VideoRepository;
 import java.util.LinkedHashMap;
@@ -14,27 +16,37 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Repository
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RestaurantQueryService {
 
+    private final RestaurantQueryRepository restaurantQueryRepository;
     private final RestaurantImageRepository restaurantImageRepository;
     private final VideoRepository videoRepository;
 
-    public List<RestaurantQueryResponse> findAll() {
-        Map<Restaurant, List<Celeb>> celebs = restaurantCelebsMap();
-        Map<Restaurant, List<RestaurantImage>> images = restaurantImagesMap();
-        return images.keySet().stream()
-                .map(restaurant -> mapToRestaurantQueryResponse(celebs, images, restaurant))
-                .toList();
+    public List<RestaurantQueryResponse> findAll(RestaurantSearchCond cond) {
+        List<Restaurant> restaurants = restaurantQueryRepository.getRestaurants(cond);
+        List<Video> videos = findVideoByRestaurantIdsIn(restaurants);
+        Map<Restaurant, List<Celeb>> celebs = mapToCeleb(groupingVideoByRestaurant(videos));
+        List<RestaurantImage> images = findImageByRestaurantIdsIn(restaurants);
+        Map<Restaurant, List<RestaurantImage>> restaurantListMap = groupingImageByRestaurant(images);
+        return toResponseList(celebs, restaurantListMap);
     }
 
-    private Map<Restaurant, List<Celeb>> restaurantCelebsMap() {
-        List<Video> videos = videoRepository.findAll();
-        Map<Restaurant, List<Video>> restaurantVideos = videos.stream()
+    private List<Video> findVideoByRestaurantIdsIn(List<Restaurant> restaurantIds) {
+        return videoRepository.findAllByRestaurantIn(restaurantIds);
+    }
+
+    private Map<Restaurant, List<Video>> groupingVideoByRestaurant(List<Video> videos) {
+        return videos.stream()
                 .collect(groupingBy(Video::restaurant, LinkedHashMap::new, Collectors.toList()));
+    }
+
+    private Map<Restaurant, List<Celeb>> mapToCeleb(Map<Restaurant, List<Video>> restaurantVideos) {
         Map<Restaurant, List<Celeb>> celebs = new LinkedHashMap<>();
         for (Restaurant restaurant : restaurantVideos.keySet()) {
             List<Celeb> list = restaurantVideos.get(restaurant).stream()
@@ -45,18 +57,29 @@ public class RestaurantQueryService {
         return celebs;
     }
 
-    private Map<Restaurant, List<RestaurantImage>> restaurantImagesMap() {
-        List<RestaurantImage> restaurantImages = restaurantImageRepository.findAll();
-        return restaurantImages.stream()
+    private List<RestaurantImage> findImageByRestaurantIdsIn(List<Restaurant> restaurantIds) {
+        return restaurantImageRepository.findAllByRestaurantIn(restaurantIds);
+    }
+
+    private Map<Restaurant, List<RestaurantImage>> groupingImageByRestaurant(List<RestaurantImage> images) {
+        return images.stream()
                 .collect(groupingBy(RestaurantImage::restaurant, LinkedHashMap::new, Collectors.toList()));
     }
 
-    private RestaurantQueryResponse mapToRestaurantQueryResponse(
-            Map<Restaurant, List<Celeb>> restaurantCelebsMap,
-            Map<Restaurant, List<RestaurantImage>> restaurantImagesMap,
+    private List<RestaurantQueryResponse> toResponseList(
+            Map<Restaurant, List<Celeb>> celebs,
+            Map<Restaurant, List<RestaurantImage>> images
+    ) {
+        return images.keySet().stream()
+                .map(restaurant -> toResponse(celebs.get(restaurant), images.get(restaurant), restaurant))
+                .toList();
+    }
+
+    private RestaurantQueryResponse toResponse(
+            List<Celeb> celebs,
+            List<RestaurantImage> images,
             Restaurant restaurant
     ) {
-        return RestaurantQueryResponse.from(restaurant, restaurantCelebsMap.get(restaurant),
-                restaurantImagesMap.get(restaurant));
+        return RestaurantQueryResponse.from(restaurant, celebs, images);
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
@@ -16,10 +16,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Repository
+@Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RestaurantQueryService {

--- a/backend/src/main/java/com/celuveat/restaurant/application/dto/CelebQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/dto/CelebQueryResponse.java
@@ -8,7 +8,7 @@ public record CelebQueryResponse(
         String youtubeChannelName,
         String profileImageUrl
 ) {
-    
+
     public static CelebQueryResponse of(Celeb it) {
         return new CelebQueryResponse(
                 it.id(),

--- a/backend/src/main/java/com/celuveat/restaurant/application/dto/RestaurantImageQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/dto/RestaurantImageQueryResponse.java
@@ -8,7 +8,7 @@ public record RestaurantImageQueryResponse(
         String author,
         String sns
 ) {
-    
+
     public static RestaurantImageQueryResponse of(RestaurantImage restaurantImage) {
         return new RestaurantImageQueryResponse(
                 restaurantImage.id(),

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantImageRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantImageRepository.java
@@ -1,6 +1,9 @@
 package com.celuveat.restaurant.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantImageRepository extends JpaRepository<RestaurantImage, Long> {
+
+    List<RestaurantImage> findAllByRestaurantIn(List<Restaurant> restaurants);
 }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -20,11 +20,12 @@ public class RestaurantQueryRepository {
     private static final String WHERE = "WHERE ";
     private static final String AND = " AND ";
 
-    private static final String CELEB_ID_EQ = "c.id = %d";
-    private static final String RESTAURANT_CATEGORY_EQ = "r.category = '%s'";
+    private static final String CELEB_ID_EQUAL = "c.id = %d";
+    private static final String RESTAURANT_CATEGORY_EQUAL = "r.category = '%s'";
     private static final String RESTAURANT_NAME_LIKE_IGNORE_CASE_IGNORE_BLANK = """
             Function('replace', lower(r.name), ' ', '') like lower('%%%s%%')
             """;
+
     private static final String SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB = """
             SELECT r
             FROM Restaurant r
@@ -33,17 +34,18 @@ public class RestaurantQueryRepository {
             JOIN Celeb c
             ON c = v.celeb
             """;
+
     private final EntityManager em;
 
     public List<Restaurant> getRestaurants(RestaurantSearchCond cond) {
         List<String> appendedQuery = new ArrayList<>();
         appendQueryIfTrue(appendedQuery,
                 notNull(cond.celebId()),
-                CELEB_ID_EQ,
+                CELEB_ID_EQUAL,
                 cond.celebId());
         appendQueryIfTrue(appendedQuery,
                 hasText(cond.category()),
-                RESTAURANT_CATEGORY_EQ,
+                RESTAURANT_CATEGORY_EQUAL,
                 cond.category());
         appendQueryIfTrue(appendedQuery,
                 hasText(cond.restaurantName()),

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -1,0 +1,140 @@
+package com.celuveat.restaurant.domain;
+
+import static com.celuveat.common.util.DynamicJpqlUtil.appendQueryIfTrue;
+import static com.celuveat.common.util.DynamicJpqlUtil.notNull;
+import static com.celuveat.common.util.StringUtil.replaceAllBlank;
+import static java.util.stream.Collectors.groupingBy;
+import static org.springframework.util.StringUtils.hasText;
+
+import com.celuveat.celeb.domain.Celeb;
+import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
+import com.celuveat.video.domain.Video;
+import com.celuveat.video.domain.VideoRepository;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestaurantQueryRepository {
+
+    private static final String WHERE = "WHERE ";
+    private static final String AND = "AND ";
+
+    private static final String CELEB_ID_EQ = "c.id = %d";
+    private static final String RESTAURANT_CATEGORY_EQ = "r.category = '%s'";
+    private static final String RESTAURANT_NAME_LIKE_IGNORE_CASE_IGNORE_BLANK = """
+            Function('replace', lower(r.name), ' ', '') like lower('%%%s%%')
+            """;
+    private static final String SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB = """
+            SELECT r
+            FROM Restaurant r
+            JOIN Video v
+            ON v.restaurant = r
+            JOIN Celeb c
+            ON c = v.celeb
+            """;
+    private final RestaurantImageRepository restaurantImageRepository;
+    private final VideoRepository videoRepository;
+    private final EntityManager em;
+
+    public List<RestaurantQueryResponse> findAll(RestaurantSearchCond cond) {
+        List<Restaurant> restaurants = getRestaurants(cond);
+        List<Video> videos = findVideoByRestaurantIdsIn(restaurants);
+        Map<Restaurant, List<Celeb>> celebs = mapToCeleb(groupingVideoByRestaurant(videos));
+        List<RestaurantImage> images = findImageByRestaurantIdsIn(restaurants);
+        Map<Restaurant, List<RestaurantImage>> restaurantListMap = groupingImageByRestaurant(images);
+        return toResponseList(celebs, restaurantListMap);
+    }
+
+    private List<Restaurant> getRestaurants(RestaurantSearchCond cond) {
+        List<String> appendedQuery = new ArrayList<>();
+        appendQueryIfTrue(appendedQuery,
+                notNull(cond.celebId()),
+                CELEB_ID_EQ,
+                cond.celebId());
+        appendQueryIfTrue(appendedQuery,
+                hasText(cond.category()),
+                RESTAURANT_CATEGORY_EQ,
+                cond.category());
+        appendQueryIfTrue(appendedQuery,
+                hasText(cond.restaurantName()),
+                RESTAURANT_NAME_LIKE_IGNORE_CASE_IGNORE_BLANK,
+                replaceAllBlank(cond.restaurantName()));
+        String query = createQuery(appendedQuery);
+        return em.createQuery(query, Restaurant.class).getResultList();
+    }
+
+    private String createQuery(List<String> appendedQuery) {
+        StringBuilder query = new StringBuilder(SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB);
+        if (!appendedQuery.isEmpty()) {
+            query.append(WHERE);
+            for (String appended : appendedQuery) {
+                query.append(appended).append(AND);
+            }
+            query.replace(query.length() - AND.length(), query.length(), "");
+        }
+        return query.toString();
+    }
+
+    private List<Video> findVideoByRestaurantIdsIn(List<Restaurant> restaurantIds) {
+        return videoRepository.findAllByRestaurantIn(restaurantIds);
+    }
+
+    private Map<Restaurant, List<Video>> groupingVideoByRestaurant(List<Video> videos) {
+        return videos.stream()
+                .collect(groupingBy(Video::restaurant, LinkedHashMap::new, Collectors.toList()));
+    }
+
+    private Map<Restaurant, List<Celeb>> mapToCeleb(Map<Restaurant, List<Video>> restaurantVideos) {
+        Map<Restaurant, List<Celeb>> celebs = new LinkedHashMap<>();
+        for (Restaurant restaurant : restaurantVideos.keySet()) {
+            List<Celeb> list = restaurantVideos.get(restaurant).stream()
+                    .map(Video::celeb)
+                    .toList();
+            celebs.put(restaurant, list);
+        }
+        return celebs;
+    }
+
+    private List<RestaurantImage> findImageByRestaurantIdsIn(List<Restaurant> restaurantIds) {
+        return restaurantImageRepository.findAllByRestaurantIn(restaurantIds);
+    }
+
+    private Map<Restaurant, List<RestaurantImage>> groupingImageByRestaurant(List<RestaurantImage> images) {
+        return images.stream()
+                .collect(groupingBy(RestaurantImage::restaurant, LinkedHashMap::new, Collectors.toList()));
+    }
+
+    private List<RestaurantQueryResponse> toResponseList(
+            Map<Restaurant, List<Celeb>> celebs,
+            Map<Restaurant, List<RestaurantImage>> images
+    ) {
+        return images.keySet().stream()
+                .map(restaurant -> toResponse(celebs.get(restaurant), images.get(restaurant), restaurant))
+                .toList();
+    }
+
+    private RestaurantQueryResponse toResponse(
+            List<Celeb> celebs,
+            List<RestaurantImage> images,
+            Restaurant restaurant
+    ) {
+        return RestaurantQueryResponse.from(restaurant, celebs, images);
+    }
+
+    record RestaurantSearchCond(
+            Long celebId,
+            String category,
+            String restaurantName
+    ) {
+    }
+}
+

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -1,7 +1,7 @@
 package com.celuveat.restaurant.domain;
 
-import static com.celuveat.common.util.DynamicJpqlUtil.appendQueryIfTrue;
-import static com.celuveat.common.util.DynamicJpqlUtil.notNull;
+import static com.celuveat.common.util.DynamicQueryUtil.appendQueryIfTrue;
+import static com.celuveat.common.util.DynamicQueryUtil.notNull;
 import static com.celuveat.common.util.StringUtil.replaceAllBlank;
 import static org.springframework.util.StringUtils.hasText;
 

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -3,19 +3,11 @@ package com.celuveat.restaurant.domain;
 import static com.celuveat.common.util.DynamicJpqlUtil.appendQueryIfTrue;
 import static com.celuveat.common.util.DynamicJpqlUtil.notNull;
 import static com.celuveat.common.util.StringUtil.replaceAllBlank;
-import static java.util.stream.Collectors.groupingBy;
 import static org.springframework.util.StringUtils.hasText;
 
-import com.celuveat.celeb.domain.Celeb;
-import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
-import com.celuveat.video.domain.Video;
-import com.celuveat.video.domain.VideoRepository;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,20 +33,9 @@ public class RestaurantQueryRepository {
             JOIN Celeb c
             ON c = v.celeb
             """;
-    private final RestaurantImageRepository restaurantImageRepository;
-    private final VideoRepository videoRepository;
     private final EntityManager em;
 
-    public List<RestaurantQueryResponse> findAll(RestaurantSearchCond cond) {
-        List<Restaurant> restaurants = getRestaurants(cond);
-        List<Video> videos = findVideoByRestaurantIdsIn(restaurants);
-        Map<Restaurant, List<Celeb>> celebs = mapToCeleb(groupingVideoByRestaurant(videos));
-        List<RestaurantImage> images = findImageByRestaurantIdsIn(restaurants);
-        Map<Restaurant, List<RestaurantImage>> restaurantListMap = groupingImageByRestaurant(images);
-        return toResponseList(celebs, restaurantListMap);
-    }
-
-    private List<Restaurant> getRestaurants(RestaurantSearchCond cond) {
+    public List<Restaurant> getRestaurants(RestaurantSearchCond cond) {
         List<String> appendedQuery = new ArrayList<>();
         appendQueryIfTrue(appendedQuery,
                 notNull(cond.celebId()),
@@ -84,53 +65,7 @@ public class RestaurantQueryRepository {
         return query.toString();
     }
 
-    private List<Video> findVideoByRestaurantIdsIn(List<Restaurant> restaurantIds) {
-        return videoRepository.findAllByRestaurantIn(restaurantIds);
-    }
-
-    private Map<Restaurant, List<Video>> groupingVideoByRestaurant(List<Video> videos) {
-        return videos.stream()
-                .collect(groupingBy(Video::restaurant, LinkedHashMap::new, Collectors.toList()));
-    }
-
-    private Map<Restaurant, List<Celeb>> mapToCeleb(Map<Restaurant, List<Video>> restaurantVideos) {
-        Map<Restaurant, List<Celeb>> celebs = new LinkedHashMap<>();
-        for (Restaurant restaurant : restaurantVideos.keySet()) {
-            List<Celeb> list = restaurantVideos.get(restaurant).stream()
-                    .map(Video::celeb)
-                    .toList();
-            celebs.put(restaurant, list);
-        }
-        return celebs;
-    }
-
-    private List<RestaurantImage> findImageByRestaurantIdsIn(List<Restaurant> restaurantIds) {
-        return restaurantImageRepository.findAllByRestaurantIn(restaurantIds);
-    }
-
-    private Map<Restaurant, List<RestaurantImage>> groupingImageByRestaurant(List<RestaurantImage> images) {
-        return images.stream()
-                .collect(groupingBy(RestaurantImage::restaurant, LinkedHashMap::new, Collectors.toList()));
-    }
-
-    private List<RestaurantQueryResponse> toResponseList(
-            Map<Restaurant, List<Celeb>> celebs,
-            Map<Restaurant, List<RestaurantImage>> images
-    ) {
-        return images.keySet().stream()
-                .map(restaurant -> toResponse(celebs.get(restaurant), images.get(restaurant), restaurant))
-                .toList();
-    }
-
-    private RestaurantQueryResponse toResponse(
-            List<Celeb> celebs,
-            List<RestaurantImage> images,
-            Restaurant restaurant
-    ) {
-        return RestaurantQueryResponse.from(restaurant, celebs, images);
-    }
-
-    record RestaurantSearchCond(
+    public record RestaurantSearchCond(
             Long celebId,
             String category,
             String restaurantName

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -54,15 +54,12 @@ public class RestaurantQueryRepository {
     }
 
     private String createQuery(List<String> appendedQuery) {
-        StringBuilder query = new StringBuilder(SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB);
-        if (!appendedQuery.isEmpty()) {
-            query.append(WHERE);
-            for (String appended : appendedQuery) {
-                query.append(appended).append(AND);
-            }
-            query.replace(query.length() - AND.length(), query.length(), "");
+        if (appendedQuery.isEmpty()) {
+            return SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB;
         }
-        return query.toString();
+        return SELECT_RESTAURANT_JOIN_VIDEO_AND_CELEB
+               + WHERE
+               + String.join(AND, appendedQuery);
     }
 
     public record RestaurantSearchCond(

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -2,7 +2,7 @@ package com.celuveat.restaurant.domain;
 
 import static com.celuveat.common.util.DynamicQueryUtil.appendQueryIfTrue;
 import static com.celuveat.common.util.DynamicQueryUtil.notNull;
-import static com.celuveat.common.util.StringUtil.replaceAllBlank;
+import static com.celuveat.common.util.StringUtil.removeAllBlank;
 import static org.springframework.util.StringUtils.hasText;
 
 import jakarta.persistence.EntityManager;
@@ -48,7 +48,7 @@ public class RestaurantQueryRepository {
         appendQueryIfTrue(appendedQuery,
                 hasText(cond.restaurantName()),
                 RESTAURANT_NAME_LIKE_IGNORE_CASE_IGNORE_BLANK,
-                replaceAllBlank(cond.restaurantName()));
+                removeAllBlank(cond.restaurantName()));
         String query = createQuery(appendedQuery);
         return em.createQuery(query, Restaurant.class).getResultList();
     }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RestaurantQueryRepository {
 
     private static final String WHERE = "WHERE ";
-    private static final String AND = "AND ";
+    private static final String AND = " AND ";
 
     private static final String CELEB_ID_EQ = "c.id = %d";
     private static final String RESTAURANT_CATEGORY_EQ = "r.category = '%s'";

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
@@ -2,10 +2,12 @@ package com.celuveat.restaurant.presentation;
 
 import com.celuveat.restaurant.application.RestaurantQueryService;
 import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository.RestaurantSearchCond;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +19,9 @@ public class RestaurantController {
     private final RestaurantQueryService restaurantQueryService;
 
     @GetMapping
-    ResponseEntity<List<RestaurantQueryResponse>> findAll() {
-        return ResponseEntity.ok(restaurantQueryService.findAll());
+    ResponseEntity<List<RestaurantQueryResponse>> findAll(
+            @ModelAttribute RestaurantSearchCond searchCond
+    ) {
+        return ResponseEntity.ok(restaurantQueryService.findAll(searchCond));
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
@@ -22,6 +22,7 @@ public class RestaurantController {
     ResponseEntity<List<RestaurantQueryResponse>> findAll(
             @ModelAttribute RestaurantSearchCond searchCond
     ) {
-        return ResponseEntity.ok(restaurantQueryService.findAll(searchCond));
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(searchCond);
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/com/celuveat/video/domain/VideoRepository.java
+++ b/backend/src/main/java/com/celuveat/video/domain/VideoRepository.java
@@ -1,6 +1,10 @@
 package com.celuveat.video.domain;
 
+import com.celuveat.restaurant.domain.Restaurant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VideoRepository extends JpaRepository<Video, Long> {
+
+    List<Video> findAllByRestaurantIn(List<Restaurant> restaurants);
 }

--- a/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceSteps.java
@@ -10,6 +10,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class CelebAcceptanceSteps {
 
@@ -28,8 +29,22 @@ public class CelebAcceptanceSteps {
                 .extract();
     }
 
+    public static List<FindAllCelebResponse> 셀럽들(
+            ExtractableResponse<Response> 응답
+    ) {
+        return 응답.as(new TypeRef<>() {
+        });
+    }
+
+    public static FindAllCelebResponse 특정_이름의_셀럽을_찾는다(List<FindAllCelebResponse> 셀럽들, String 셀럽) {
+        return 셀럽들.stream()
+                .filter(it -> it.name().equals(셀럽))
+                .findAny()
+                .orElseThrow(NoSuchElementException::new);
+    }
+
     public static void 셀럽_전체_조회_결과를_검증한다(List<FindAllCelebResponse> 예상, ExtractableResponse<Response> 응답) {
-        var result = 응답.as(new TypeRef<>() {
+        List<FindAllCelebResponse> result = 응답.as(new TypeRef<>() {
         });
         assertThat(result).usingRecursiveComparison()
                 .ignoringFields("id")

--- a/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceSteps.java
@@ -1,0 +1,38 @@
+package com.celuveat.acceptance.celeb;
+
+import static com.celuveat.acceptance.common.AcceptanceSteps.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.celeb.fixture.CelebFixture;
+import com.celuveat.celeb.presentation.response.FindAllCelebResponse;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Arrays;
+import java.util.List;
+
+public class CelebAcceptanceSteps {
+
+    public static List<FindAllCelebResponse> 예상_셀럽조회_결과(String... 셀럽들_이름) {
+        return Arrays.stream(셀럽들_이름)
+                .map(CelebFixture::셀럽)
+                .map(FindAllCelebResponse::from)
+                .toList();
+    }
+
+    public static ExtractableResponse<Response> 셀럽_전체_조회_요청() {
+        return given()
+                .when()
+                .get("/api/celebs")
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 셀럽_전체_조회_결과를_검증한다(List<FindAllCelebResponse> 예상, ExtractableResponse<Response> 응답) {
+        var result = 응답.as(new TypeRef<>() {
+        });
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFields("id")
+                .isEqualTo(예상);
+    }
+}

--- a/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/celeb/CelebAcceptanceTest.java
@@ -1,0 +1,42 @@
+package com.celuveat.acceptance.celeb;
+
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.셀럽_전체_조회_결과를_검증한다;
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.셀럽_전체_조회_요청;
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.예상_셀럽조회_결과;
+
+import com.celuveat.acceptance.common.AcceptanceTest;
+import com.celuveat.celeb.domain.Celeb;
+import com.celuveat.celeb.domain.CelebRepository;
+import com.celuveat.celeb.fixture.CelebFixture;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("셀럽 인수테스트")
+public class CelebAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private CelebRepository celebRepository;
+
+    @Test
+    void 모든_셀럽들을_조회한다() {
+        // given
+        셀럽들을_저장한다("말랑", "로이스", "오도", "도기", "도담", "제레미", "푸만능");
+        var 예상 = 예상_셀럽조회_결과("말랑", "로이스", "오도", "도기", "도담", "제레미", "푸만능");
+
+        // when
+        var 응답 = 셀럽_전체_조회_요청();
+
+        // then
+        셀럽_전체_조회_결과를_검증한다(예상, 응답);
+    }
+
+    private void 셀럽들을_저장한다(String... 셀럽들_이름) {
+        List<Celeb> list = Arrays.stream(셀럽들_이름)
+                .map(CelebFixture::셀럽)
+                .toList();
+        celebRepository.saveAll(list);
+    }
+}

--- a/backend/src/test/java/com/celuveat/acceptance/common/AcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/common/AcceptanceSteps.java
@@ -21,6 +21,8 @@ public class AcceptanceSteps {
     public static final HttpStatus 찾을수_없음 = HttpStatus.NOT_FOUND;
     public static final HttpStatus 중복됨 = HttpStatus.CONFLICT;
 
+    public static final Object 없음 = null;
+
     public static LocalDateTime 현재시간() {
         return LocalDateTime.now();
     }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
@@ -75,7 +75,7 @@ public class RestaurantAcceptanceSteps {
         if (restaurantName == null) {
             return true;
         }
-        return restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName));
+        return restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName));
     }
 
     private static boolean 카테고리_조건(String category, RestaurantQueryResponse restaurantQueryResponse) {

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
@@ -3,19 +3,40 @@ package com.celuveat.acceptance.restaurant;
 import static com.celuveat.acceptance.common.AcceptanceSteps.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.celuveat.common.util.StringUtil;
+import com.celuveat.restaurant.application.dto.CelebQueryResponse;
 import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository.RestaurantSearchCond;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RestaurantAcceptanceSteps {
 
-    public static ExtractableResponse<Response> 음식점_전체_조회_요청() {
+    public static ExtractableResponse<Response> 음식점_검색_요청(
+            RestaurantSearchCond 검색_조건
+    ) {
+        Map<String, Object> param = new HashMap<>();
+        param.put("celebId", 검색_조건.celebId());
+        param.put("category", 검색_조건.category());
+        param.put("restaurantName", 검색_조건.restaurantName());
         return given()
+                .queryParams(param)
                 .when().get("/api/restaurants")
                 .then().log().all()
                 .extract();
+    }
+
+    public static RestaurantSearchCond 검색_조건(
+            Object 셀럽_ID,
+            Object 카테고리,
+            Object 음식점_이름
+    ) {
+        return new RestaurantSearchCond((Long) 셀럽_ID, (String) 카테고리, (String) 음식점_이름);
     }
 
     public static void 조회_결과를_검증한다(List<RestaurantQueryResponse> 예상_응답, ExtractableResponse<Response> 응답) {
@@ -24,4 +45,51 @@ public class RestaurantAcceptanceSteps {
         assertThat(restaurantQueryResponse).usingRecursiveComparison()
                 .isEqualTo(예상_응답);
     }
+
+    public static List<RestaurantQueryResponse> 예상_응답(
+            List<RestaurantQueryResponse> 전체_음식점,
+            Object 셀럽_ID,
+            Object 카테고리,
+            Object 음식점_이름
+    ) {
+        List<RestaurantQueryResponse> 예상_응답 = new ArrayList<>();
+        Long celebId = (Long) 셀럽_ID;
+        String category = (String) 카테고리;
+        String restaurantName = (String) 음식점_이름;
+        for (RestaurantQueryResponse restaurantQueryResponse : 전체_음식점) {
+            List<Long> list = restaurantQueryResponse.celebs()
+                    .stream()
+                    .map(CelebQueryResponse::id)
+                    .toList();
+
+            if (음식점_이름_조건(restaurantName, restaurantQueryResponse)
+                && 카테고리_조건(category, restaurantQueryResponse)
+                && 셀럽_조건(celebId, list)) {
+                예상_응답.add(restaurantQueryResponse);
+            }
+        }
+        return 예상_응답;
+    }
+
+    private static boolean 음식점_이름_조건(String restaurantName, RestaurantQueryResponse restaurantQueryResponse) {
+        if (restaurantName == null) {
+            return true;
+        }
+        return restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName));
+    }
+
+    private static boolean 카테고리_조건(String category, RestaurantQueryResponse restaurantQueryResponse) {
+        if (category == null) {
+            return true;
+        }
+        return restaurantQueryResponse.category().equals(category);
+    }
+
+    private static boolean 셀럽_조건(Long celebId, List<Long> list) {
+        if (celebId == null) {
+            return true;
+        }
+        return list.contains(celebId);
+    }
+
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
@@ -1,11 +1,18 @@
 package com.celuveat.acceptance.restaurant;
 
-import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_전체_조회_요청;
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.셀럽_전체_조회_요청;
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.셀럽들;
+import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.특정_이름의_셀럽을_찾는다;
+import static com.celuveat.acceptance.common.AcceptanceSteps.없음;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.검색_조건;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.예상_응답;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_검색_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.조회_결과를_검증한다;
 
 import com.celuveat.acceptance.common.AcceptanceTest;
 import com.celuveat.common.SeedData;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -15,15 +22,34 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
     @Autowired
     private SeedData seedData;
 
-    @Test
-    void 모든_음식점을_조회한다() {
-        // given
-        var 예상_응답 = seedData.insertSeedData();
+    @Nested
+    class 음식점_검색 {
 
-        // when
-        var 응답 = 음식점_전체_조회_요청();
+        @Test
+        void 모든_음식점을_조회한다() {
+            // given
+            var 예상_응답 = seedData.insertSeedData();
 
-        // then
-        조회_결과를_검증한다(예상_응답, 응답);
+            // when
+            var 응답 = 음식점_검색_요청(검색_조건(없음, 없음, 없음));
+
+            // then
+            조회_결과를_검증한다(예상_응답, 응답);
+        }
+
+        @Test
+        void 검색한다() {
+            // given
+            var 전체_음식점 = seedData.insertSeedData();
+            var 셀럽들 = 셀럽들(셀럽_전체_조회_요청());
+            var 말랑 = 특정_이름의_셀럽을_찾는다(셀럽들, "말랑");
+            var 예상_응답 = 예상_응답(전체_음식점, 말랑.id(), 없음, "말 랑 ");
+
+            // when
+            var 응답 = 음식점_검색_요청(검색_조건(말랑.id(), 없음, "말 랑 "));
+
+            // then
+            조회_결과를_검증한다(예상_응답, 응답);
+        }
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -28,10 +28,13 @@ import org.springframework.transaction.annotation.Transactional;
 class RestaurantQueryServiceTest {
 
     private final List<RestaurantQueryResponse> seed = new ArrayList<>();
+
     @Autowired
     private SeedData seedData;
+
     @Autowired
     private EntityManager em;
+
     @Autowired
     private RestaurantQueryService restaurantQueryService;
 

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -3,8 +3,14 @@ package com.celuveat.restaurant.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.celuveat.common.SeedData;
+import com.celuveat.common.util.StringUtil;
+import com.celuveat.restaurant.application.dto.CelebQueryResponse;
 import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository.RestaurantSearchCond;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -21,21 +27,194 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class RestaurantQueryServiceTest {
 
+    private final List<RestaurantQueryResponse> seed = new ArrayList<>();
     @Autowired
     private SeedData seedData;
-
+    @Autowired
+    private EntityManager em;
     @Autowired
     private RestaurantQueryService restaurantQueryService;
 
+    @BeforeEach
+    void setUp() {
+        seed.addAll(seedData.insertSeedData());
+        em.flush();
+        em.clear();
+        System.out.println("=============[INSERT SEED DATA]============");
+    }
+
     @Test
     void 전체_음식점_조회_테스트() {
-        // given
-        List<RestaurantQueryResponse> expected = seedData.insertSeedData();
-
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryService.findAll();
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(null, null, null));
 
         // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(seed);
+    }
+
+    @Test
+    void 셀럽으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 1L;
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(celebId, null, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 카테고리로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String category = "category:오도1호점";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(null, category, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 음식점_이름_포함으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String restaurantName = " 말 랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(null, null, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_카테고리로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 1L;
+        String category = "category:오도1호점";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (list.contains(celebId) && restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(celebId, category, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 2L;
+        String restaurantName = "\n      말 \n랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(celebId, null, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 카테고리와_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String category = "category:말랑2호점";
+        String restaurantName = "\n      말 \n랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(null, category, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_카테고리와_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 2L;
+        String category = "category:로이스1호점";
+        String restaurantName = "로 이스";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && restaurantQueryResponse.category().equals(category)
+                && list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryService.findAll(
+                new RestaurantSearchCond(celebId, category, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
                 .isEqualTo(expected);
     }

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -108,7 +108,7 @@ class RestaurantQueryServiceTest {
         List<RestaurantQueryResponse> expected = new ArrayList<>();
         String restaurantName = " 말 랑  \n";
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))) {
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))) {
                 expected.add(restaurantQueryResponse);
             }
         }
@@ -156,7 +156,7 @@ class RestaurantQueryServiceTest {
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
             List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
                     .toList();
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && list.contains(celebId)) {
                 expected.add(restaurantQueryResponse);
             }
@@ -179,7 +179,7 @@ class RestaurantQueryServiceTest {
         String category = "category:말랑2호점";
         String restaurantName = "\n      말 \n랑  \n";
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && restaurantQueryResponse.category().equals(category)) {
                 expected.add(restaurantQueryResponse);
             }
@@ -205,7 +205,7 @@ class RestaurantQueryServiceTest {
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
             List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
                     .toList();
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && restaurantQueryResponse.category().equals(category)
                 && list.contains(celebId)) {
                 expected.add(restaurantQueryResponse);

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -1,0 +1,221 @@
+package com.celuveat.restaurant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.common.SeedData;
+import com.celuveat.common.util.StringUtil;
+import com.celuveat.restaurant.application.dto.CelebQueryResponse;
+import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
+import com.celuveat.restaurant.domain.RestaurantQueryRepository.RestaurantSearchCond;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@Sql("/truncate.sql")
+@DisplayName("RestaurantQueryRepository 은(는)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RestaurantQueryRepositoryTest {
+
+    private final List<RestaurantQueryResponse> seed = new ArrayList<>();
+    @Autowired
+    private SeedData seedData;
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private RestaurantQueryRepository restaurantQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        seed.addAll(seedData.insertSeedData());
+        em.flush();
+        em.clear();
+        System.out.println("=============[INSERT SEED DATA]============");
+    }
+
+    @Test
+    void 전체_음식점_조회_테스트() {
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(null, null, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(seed);
+    }
+
+    @Test
+    void 셀럽으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 1L;
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(celebId, null, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 카테고리로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String category = "category:오도1호점";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(null, category, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 음식점_이름_포함으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String restaurantName = " 말 랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(null, null, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_카테고리로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 1L;
+        String category = "category:오도1호점";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (list.contains(celebId) && restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(celebId, category, null));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 2L;
+        String restaurantName = "\n      말 \n랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(celebId, null, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 카테고리와_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        String category = "category:말랑2호점";
+        String restaurantName = "\n      말 \n랑  \n";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && restaurantQueryResponse.category().equals(category)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(null, category, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽과_카테고리와_음식점_이름으로_조회_테스트() {
+        // given
+        List<RestaurantQueryResponse> expected = new ArrayList<>();
+        Long celebId = 2L;
+        String category = "category:로이스1호점";
+        String restaurantName = "로 이스";
+        for (RestaurantQueryResponse restaurantQueryResponse : seed) {
+            List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
+                    .toList();
+            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+                && restaurantQueryResponse.category().equals(category)
+                && list.contains(celebId)) {
+                expected.add(restaurantQueryResponse);
+            }
+        }
+
+        // when
+        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+                new RestaurantSearchCond(celebId, category, restaurantName));
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -46,6 +46,12 @@ class RestaurantQueryRepositoryTest {
         System.out.println("=============[INSERT SEED DATA]============");
     }
 
+    private List<String> 이름_추출(List<RestaurantQueryResponse> list) {
+        return list.stream()
+                .map(RestaurantQueryResponse::name)
+                .toList();
+    }
+
     @Test
     void 전체_음식점_조회_테스트() {
         // when
@@ -54,10 +60,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(seed.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(seed);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(seed));
     }
 
     @Test
@@ -79,10 +83,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -102,10 +104,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -118,7 +118,7 @@ class RestaurantQueryRepositoryTest {
                 expected.add(restaurantQueryResponse);
             }
         }
-
+        
         // when
         List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, null, restaurantName));
@@ -126,9 +126,8 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -151,10 +150,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -178,10 +175,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -203,11 +198,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+        assertThat(result).extracting(Restaurant::name)
+                .containsExactlyElementsOf(이름_추출(expected));
     }
 
     @Test
@@ -234,8 +226,6 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).hasSize(expected.size());
-        assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFieldsOfTypes(Restaurant.class)
-                .isEqualTo(expected);
+
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -28,10 +28,13 @@ import org.springframework.transaction.annotation.Transactional;
 class RestaurantQueryRepositoryTest {
 
     private final List<RestaurantQueryResponse> seed = new ArrayList<>();
+
     @Autowired
     private SeedData seedData;
+
     @Autowired
     private EntityManager em;
+    
     @Autowired
     private RestaurantQueryRepository restaurantQueryRepository;
 

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -52,7 +52,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(seed);
     }
 
@@ -76,7 +76,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -98,7 +98,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -120,7 +120,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -145,7 +145,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -171,7 +171,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -195,7 +195,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 
@@ -223,7 +223,7 @@ class RestaurantQueryRepositoryTest {
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
-                .comparingOnlyFields("name")
+                .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -46,12 +46,13 @@ class RestaurantQueryRepositoryTest {
     @Test
     void 전체_음식점_조회_테스트() {
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, null, null));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(seed);
     }
 
@@ -69,12 +70,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(celebId, null, null));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -90,12 +92,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, category, null));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -111,12 +114,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, null, restaurantName));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -135,12 +139,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(celebId, category, null));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -160,12 +165,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(celebId, null, restaurantName));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -183,12 +189,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, category, restaurantName));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 
@@ -210,12 +217,13 @@ class RestaurantQueryRepositoryTest {
         }
 
         // when
-        List<RestaurantQueryResponse> result = restaurantQueryRepository.findAll(
+        List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(celebId, category, restaurantName));
 
         // then
         assertThat(result).isNotEmpty();
         assertThat(result).usingRecursiveComparison()
+                .comparingOnlyFields("name")
                 .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -34,7 +34,7 @@ class RestaurantQueryRepositoryTest {
 
     @Autowired
     private EntityManager em;
-    
+
     @Autowired
     private RestaurantQueryRepository restaurantQueryRepository;
 
@@ -54,6 +54,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(seed.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(seed);
@@ -78,6 +79,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -100,6 +102,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -122,6 +125,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -147,6 +151,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -173,6 +178,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -197,6 +203,8 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);
@@ -225,6 +233,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(expected.size());
         assertThat(result).usingRecursiveComparison()
                 .comparingOnlyFieldsOfTypes(Restaurant.class)
                 .isEqualTo(expected);

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -114,11 +114,11 @@ class RestaurantQueryRepositoryTest {
         List<RestaurantQueryResponse> expected = new ArrayList<>();
         String restaurantName = " 말 랑  \n";
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))) {
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))) {
                 expected.add(restaurantQueryResponse);
             }
         }
-        
+
         // when
         List<Restaurant> result = restaurantQueryRepository.getRestaurants(
                 new RestaurantSearchCond(null, null, restaurantName));
@@ -163,7 +163,7 @@ class RestaurantQueryRepositoryTest {
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
             List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
                     .toList();
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && list.contains(celebId)) {
                 expected.add(restaurantQueryResponse);
             }
@@ -186,7 +186,7 @@ class RestaurantQueryRepositoryTest {
         String category = "category:말랑2호점";
         String restaurantName = "\n      말 \n랑  \n";
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && restaurantQueryResponse.category().equals(category)) {
                 expected.add(restaurantQueryResponse);
             }
@@ -212,7 +212,7 @@ class RestaurantQueryRepositoryTest {
         for (RestaurantQueryResponse restaurantQueryResponse : seed) {
             List<Long> list = restaurantQueryResponse.celebs().stream().map(CelebQueryResponse::id)
                     .toList();
-            if (restaurantQueryResponse.name().contains(StringUtil.replaceAllBlank(restaurantName))
+            if (restaurantQueryResponse.name().contains(StringUtil.removeAllBlank(restaurantName))
                 && restaurantQueryResponse.category().equals(category)
                 && list.contains(celebId)) {
                 expected.add(restaurantQueryResponse);

--- a/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantFixture.java
+++ b/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantFixture.java
@@ -10,7 +10,7 @@ public class RestaurantFixture {
                 .roadAddress(name)
                 .naverMapUrl(name)
                 .phoneNumber(name)
-                .category(name)
+                .category("category:" + name)
                 .latitude("37.5206993")
                 .longitude("127.019975")
                 .build();


### PR DESCRIPTION
## ✨ 요약
```
 셀럽 전체 조회 기능 구현
 셀럽 ID와 카테고리, 음식점 이름으로 음식점 검색 API 작성
```

<br><br>

## 😎 해결한 이슈
- close #147 

<br><br>

## More
```
아직 동적쿼리가 많이 필요한것도 아니고, 간단해서 JPQL로 동적쿼리 만들어서 했어~
QueryDSL이 더 편할 것 같은데, 배우는 데 시간도 걸릴 것 같구!
```
