### PR TITLE
fix: react testing library 사용 시 에러 이미지 import 시 에러 발생

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -29,7 +29,7 @@
       "version": "detect"
     }
   },
-  "ignorePatterns": ["build", "dist", "public", "webpack.**.js", "mocks"],
+  "ignorePatterns": ["build", "dist", "public", "webpack.**.js", "mocks", "fileTransformer.js"],
   "rules": {
     "no-console": "warn",
     "react/react-in-jsx-scope": "off",

--- a/frontend/fileTransformer.js
+++ b/frontend/fileTransformer.js
@@ -1,0 +1,10 @@
+// fileTransformer.js
+const path = require('path');
+
+module.exports = {
+  process(sourceText, sourcePath, options) {
+    return {
+      code: `module.exports = ${JSON.stringify(path.basename(sourcePath))};`,
+    };
+  },
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -5,5 +5,10 @@ module.exports = {
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/fileTransformer.js',
+  },
+  moduleNameMapper: {
+    '^\\~/(.*)$': '<rootDir>/src/$1',
   },
 };


### PR DESCRIPTION
## ✨ 요약

`import * from ~.png` 등의 구문이 포함되어 있는 컴포넌트를 테스트 시 발생하던 에러 해결


## 😎 해결한 이슈
- close #154 
