### PR TITLE
feat: 셀럽 저장 api 구현

### DIFF
--- a/backend/src/main/java/com/celuveat/admin/application/AdminService.java
+++ b/backend/src/main/java/com/celuveat/admin/application/AdminService.java
@@ -4,6 +4,7 @@ import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_DATE_FORMA
 import static com.celuveat.restaurant.domain.SocialMedia.YOUTUBE;
 
 import com.celuveat.admin.exception.AdminException;
+import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
 import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.celeb.domain.CelebRepository;
@@ -61,5 +62,12 @@ public class AdminService {
         restaurantRepository.save(restaurant);
         restaurantImageRepository.save(restaurantImage);
         videoRepository.save(video);
+    }
+
+    public void saveCelebs(List<SaveCelebRequest> requests) {
+        List<Celeb> celebs = requests.stream()
+                .map(SaveCelebRequest::toCeleb)
+                .toList();
+        celebRepository.saveAll(celebs);
     }
 }

--- a/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
+++ b/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
@@ -10,8 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum AdminExceptionType implements BaseExceptionType {
 
     NOT_EXISTS_CELEB(BAD_REQUEST, "셀럽이 저장되어 있지 않습니다. 셀럽 먼저 저장해주세요."),
-    ILLEGAL_DATE_FORMAT(BAD_REQUEST, "영상 업로드 날짜 형식이 잘못됐습니다. \'yyyy. M. d\' 형식으로 입력해주세요."),
+    ILLEGAL_DATE_FORMAT(BAD_REQUEST, "영상 업로드 날짜 형식이 잘못됐습니다. \'yyyy. MM. dd\' 형식으로 입력해주세요."),
     ILLEGAL_FORMAT(BAD_REQUEST, "데이터 저장 양식이 잘못됐습니다. 엑셀 폼을 준수해주세요."),
+    EXIST_NULL(BAD_REQUEST, "입력되지 않은 값이 있습니다."),
+    INVALID_YOUTUBE_CHANNEL_NAME(BAD_REQUEST, "유튜브 채널 명이 잘못됐습니다. 앞에 '@'를 붙여주세요."),
+    INVALID_URL_PATTERN(BAD_REQUEST, "URL 패턴이 잘못됐습니다. 확인 후 다시 입력해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
+++ b/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
@@ -11,6 +11,7 @@ public enum AdminExceptionType implements BaseExceptionType {
 
     NOT_EXISTS_CELEB(BAD_REQUEST, "셀럽이 저장되어 있지 않습니다. 셀럽 먼저 저장해주세요."),
     ILLEGAL_DATE_FORMAT(BAD_REQUEST, "영상 업로드 날짜 형식이 잘못됐습니다. \'yyyy. M. d\' 형식으로 입력해주세요."),
+    ILLEGAL_FORMAT(BAD_REQUEST, "데이터 저장 양식이 잘못됐습니다. 엑셀 폼을 준수해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
@@ -1,10 +1,12 @@
 package com.celuveat.admin.presentation;
 
 import com.celuveat.admin.application.AdminService;
+import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin")
 public class AdminController {
 
-    private static final String TAB = "\t";
+    static final String TAB = "\t";
 
     private final AdminService adminService;
 
@@ -28,6 +30,17 @@ public class AdminController {
                 .map(SaveDataRequest::from)
                 .toList();
         adminService.saveData(requests);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/celebs")
+    ResponseEntity<Void> saveCelebs(@RequestBody String rawData) {
+        String[] rows = rawData.split(System.lineSeparator());
+        List<SaveCelebRequest> requests = Arrays.stream(rows)
+                .map(row -> row.split(TAB, -1))
+                .map(SaveCelebRequest::new)
+                .toList();
+        adminService.saveCelebs(requests);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Profile("!prod")
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveCelebRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveCelebRequest.java
@@ -1,6 +1,8 @@
 package com.celuveat.admin.presentation.dto;
 
-import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_FORMAT;
+import static com.celuveat.admin.exception.AdminExceptionType.EXIST_NULL;
+import static com.celuveat.admin.exception.AdminExceptionType.INVALID_URL_PATTERN;
+import static com.celuveat.admin.exception.AdminExceptionType.INVALID_YOUTUBE_CHANNEL_NAME;
 
 import com.celuveat.admin.exception.AdminException;
 import com.celuveat.celeb.domain.Celeb;
@@ -25,20 +27,20 @@ public record SaveCelebRequest(
     private void validateNullOrBlank(String[] data) {
         for (String field : data) {
             if (field == null || field.isBlank()) {
-                throw new AdminException(ILLEGAL_FORMAT);
+                throw new AdminException(EXIST_NULL);
             }
         }
     }
 
     private void validateYoutubeChannelNamePattern(String youtubeChannelName) {
         if (!youtubeChannelName.startsWith("@")) {
-            throw new AdminException(ILLEGAL_FORMAT);
+            throw new AdminException(INVALID_YOUTUBE_CHANNEL_NAME);
         }
     }
 
     private void validateUrlPattern(String profileImageUrl) {
         if (!profileImageUrl.startsWith("https://")) {
-            throw new AdminException(ILLEGAL_FORMAT);
+            throw new AdminException(INVALID_URL_PATTERN);
         }
     }
 

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveCelebRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveCelebRequest.java
@@ -1,0 +1,52 @@
+package com.celuveat.admin.presentation.dto;
+
+import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_FORMAT;
+
+import com.celuveat.admin.exception.AdminException;
+import com.celuveat.celeb.domain.Celeb;
+
+public record SaveCelebRequest(
+        String name,
+        String youtubeChannelName,
+        String profileImageUrl
+) {
+
+    private static final int CELEB_NAME = 0;
+    private static final int YOUTUBE_CHANNEL_NAME = 1;
+    private static final int PROFILE_IMAGE_URL = 2;
+
+    public SaveCelebRequest(String[] data) {
+        this(data[CELEB_NAME], data[YOUTUBE_CHANNEL_NAME], data[PROFILE_IMAGE_URL]);
+        validateNullOrBlank(data);
+        validateYoutubeChannelNamePattern(data[YOUTUBE_CHANNEL_NAME]);
+        validateUrlPattern(data[PROFILE_IMAGE_URL]);
+    }
+
+    private void validateNullOrBlank(String[] data) {
+        for (String field : data) {
+            if (field == null || field.isBlank()) {
+                throw new AdminException(ILLEGAL_FORMAT);
+            }
+        }
+    }
+
+    private void validateYoutubeChannelNamePattern(String youtubeChannelName) {
+        if (!youtubeChannelName.startsWith("@")) {
+            throw new AdminException(ILLEGAL_FORMAT);
+        }
+    }
+
+    private void validateUrlPattern(String profileImageUrl) {
+        if (!profileImageUrl.startsWith("https://")) {
+            throw new AdminException(ILLEGAL_FORMAT);
+        }
+    }
+
+    public Celeb toCeleb() {
+        return Celeb.builder()
+                .name(name)
+                .youtubeChannelName(youtubeChannelName)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class AdminAcceptanceSteps {
 
-    private static final String TAB = "\t";
+    public static final String TAB = "\t";
 
     public static String 데이터_입력_생성(String 셀럽_이름, String 음식점_이름) {
         return "@" + 셀럽_이름 +

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
@@ -4,6 +4,7 @@ import static com.celuveat.acceptance.common.AcceptanceSteps.given;
 import static io.restassured.http.ContentType.TEXT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -12,7 +13,9 @@ import java.util.List;
 
 public class AdminAcceptanceSteps {
 
-    public static String 입력_생성(String 셀럽_이름, String 음식점_이름) {
+    private static final String TAB = "\t";
+
+    public static String 데이터_입력_생성(String 셀럽_이름, String 음식점_이름) {
         return "@" + 셀럽_이름 +
                 "\t" + 음식점_이름 + "png" +
                 "\t유튜브링크" +
@@ -26,10 +29,10 @@ public class AdminAcceptanceSteps {
                 "\t12.3456";
     }
 
-    public static List<SaveDataRequest> 요청_생성(String input) {
+    public static List<SaveDataRequest> 데이터_저장_요청_생성(String input) {
         String[] rows = input.split(System.lineSeparator());
         return Arrays.stream(rows)
-                .map(row -> row.split("\t"))
+                .map(row -> row.split(TAB))
                 .map(SaveDataRequest::from)
                 .toList();
     }
@@ -39,6 +42,29 @@ public class AdminAcceptanceSteps {
                 .contentType(TEXT.withCharset(UTF_8))
                 .body(data)
                 .when().post("/api/admin/data")
+                .then().log().all()
+                .extract();
+    }
+
+    public static String 셀럽_입력_생성(String 셀럽_이름) {
+        return 셀럽_이름
+                + "\t@%s".formatted(셀럽_이름)
+                + "\thttps://profileImageUrl";
+    }
+
+    public static List<SaveCelebRequest> 셀럽_저장_요청_생성(String input) {
+        String[] rows = input.split(System.lineSeparator());
+        return Arrays.stream(rows)
+                .map(row -> row.split(TAB, -1))
+                .map(SaveCelebRequest::new)
+                .toList();
+    }
+
+    public static ExtractableResponse<Response> 셀럽_저장_요청(String data) {
+        return given()
+                .contentType(TEXT.withCharset(UTF_8))
+                .body(data)
+                .when().post("/api/admin/celebs")
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
@@ -5,7 +5,8 @@ import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저�
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청_생성;
-import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_FORMAT;
+import static com.celuveat.admin.exception.AdminExceptionType.EXIST_NULL;
+import static com.celuveat.admin.exception.AdminExceptionType.INVALID_URL_PATTERN;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -98,7 +99,7 @@ class AdminAcceptanceTest extends AcceptanceTest {
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
                 .exceptionType();
-        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+        assertThat(exceptionType).isEqualTo(EXIST_NULL);
     }
 
     @Test
@@ -109,7 +110,7 @@ class AdminAcceptanceTest extends AcceptanceTest {
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
                 .exceptionType();
-        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+        assertThat(exceptionType).isEqualTo(EXIST_NULL);
     }
 
     @Test
@@ -120,17 +121,17 @@ class AdminAcceptanceTest extends AcceptanceTest {
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
                 .exceptionType();
-        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+        assertThat(exceptionType).isEqualTo(EXIST_NULL);
     }
 
     @Test
     void 데이터_순서가_다르면_예외가_발생한다() {
         // given
-        String input = "@도기\t도기\thttps://이미지";
+        String input = "https://\t@도기\t@도기";
 
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
                 .exceptionType();
-        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+        assertThat(exceptionType).isEqualTo(INVALID_URL_PATTERN);
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
@@ -1,12 +1,19 @@
 package com.celuveat.acceptance.admin;
 
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저장_요청;
-import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.입력_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청_생성;
+import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_FORMAT;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.celuveat.acceptance.common.AcceptanceTest;
+import com.celuveat.admin.exception.AdminException;
 import com.celuveat.celeb.domain.Celeb;
+import com.celuveat.common.exception.BaseExceptionType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,17 +30,17 @@ class AdminAcceptanceTest extends AcceptanceTest {
         셀럽_저장(셀럽("말랑"));
         셀럽_저장(셀럽("오도"));
 
-        String 입력_데이터 = 입력_생성("도기", "국민연금")
+        String 입력_데이터 = 데이터_입력_생성("도기", "국민연금")
                 + 줄바꿈
-                + 입력_생성("도기", "농민백암순대")
+                + 데이터_입력_생성("도기", "농민백암순대")
                 + 줄바꿈
-                + 입력_생성("로이스", "신천직화")
+                + 데이터_입력_생성("로이스", "신천직화")
                 + 줄바꿈
-                + 입력_생성("오도", "국민연금")
+                + 데이터_입력_생성("오도", "국민연금")
                 + 줄바꿈
-                + 입력_생성("말랑", "바스버거")
+                + 데이터_입력_생성("말랑", "바스버거")
                 + 줄바꿈
-                + 입력_생성("말랑", "신천직화");
+                + 데이터_입력_생성("말랑", "신천직화");
 
         // when
         데이터_저장_요청(입력_데이터);
@@ -63,5 +70,67 @@ class AdminAcceptanceTest extends AcceptanceTest {
 
     private void 영상_수_검증(int expected) {
         assertThat(videoRepository.count()).isEqualTo(expected);
+    }
+
+    @Test
+    void 셀럽을_저장한다() {
+        // given
+        String 입력_데이터 = 셀럽_입력_생성("도기")
+                + 줄바꿈
+                + 셀럽_입력_생성("말랑")
+                + 줄바꿈
+                + 셀럽_입력_생성("오도")
+                + 줄바꿈
+                + 셀럽_입력_생성("로이스");
+
+        // when
+        셀럽_저장_요청(입력_데이터);
+
+        // then
+        assertThat(celebRepository.count()).isEqualTo(4);
+    }
+
+    @Test
+    void 셀럽_이름이_누락되면_예외가_발생한다() {
+        // given
+        String input = "\t@도기\thttps://이미지";
+
+        // then
+        BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
+                .exceptionType();
+        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+    }
+
+    @Test
+    void 셀럽의_유튜브_채널_이름이_누락되면_예외가_발생한다() {
+        // given
+        String input = "도기\t\thttps://이미지";
+
+        // then
+        BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
+                .exceptionType();
+        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+    }
+
+    @Test
+    void 셀럽의_프로필_사진_URL이_누락되면_예외가_발생한다() {
+        // given
+        String input = "도기\t@도기\t";
+
+        // then
+        BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
+                .exceptionType();
+        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
+    }
+
+    @Test
+    void 데이터_순서가_다르면_예외가_발생한다() {
+        // given
+        String input = "@도기\t도기\thttps://이미지";
+
+        // then
+        BaseExceptionType exceptionType = assertThrows(AdminException.class, () -> 셀럽_저장_요청_생성(input))
+                .exceptionType();
+        assertThat(exceptionType).isEqualTo(ILLEGAL_FORMAT);
     }
 }

--- a/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
@@ -1,7 +1,9 @@
 package com.celuveat.admin.application;
 
-import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.요청_생성;
-import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.입력_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_입력_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저장_요청_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청_생성;
 import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_DATE_FORMAT;
 import static com.celuveat.admin.exception.AdminExceptionType.NOT_EXISTS_CELEB;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
@@ -10,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.celuveat.admin.exception.AdminException;
+import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
 import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.celeb.domain.CelebRepository;
@@ -51,8 +54,8 @@ class AdminServiceTest {
     @Test
     void 저장되어_있지_않은_셀럽으로_데이터를_저장하면_예외가_발생한다() {
         // given
-        String input = 입력_생성("도기", "국민연금");
-        List<SaveDataRequest> 요청 = 요청_생성(input);
+        String input = 데이터_입력_생성("도기", "국민연금");
+        List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class,
@@ -68,7 +71,7 @@ class AdminServiceTest {
 
         // when
         String input = 잘못된_입력_생성("도기", "농민백암순대", 영상_업로드_날짜);
-        List<SaveDataRequest> 요청 = 요청_생성(input);
+        List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
         // then
         BaseExceptionType exceptionType = assertThrows(AdminException.class,
@@ -82,8 +85,8 @@ class AdminServiceTest {
         셀럽_저장(셀럽("도기"));
         음식점_저장(국민연금_구내식당);
 
-        String input = 입력_생성("도기", "국민연금") + System.lineSeparator() + 입력_생성("도기", "농민백암순대");
-        List<SaveDataRequest> 요청 = 요청_생성(input);
+        String input = 데이터_입력_생성("도기", "국민연금") + System.lineSeparator() + 데이터_입력_생성("도기", "농민백암순대");
+        List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
         // when
         adminService.saveData(요청);
@@ -102,8 +105,8 @@ class AdminServiceTest {
         셀럽_저장(셀럽("로이스"));
         음식점_저장(국민연금_구내식당);
 
-        String input = 입력_생성("도기", "국민연금") + System.lineSeparator() + 입력_생성("로이스", "국민연금");
-        List<SaveDataRequest> 요청 = 요청_생성(input);
+        String input = 데이터_입력_생성("도기", "국민연금") + System.lineSeparator() + 데이터_입력_생성("로이스", "국민연금");
+        List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
         // when
         adminService.saveData(요청);
@@ -120,8 +123,8 @@ class AdminServiceTest {
         // given
         셀럽_저장(셀럽("도기"));
 
-        String input = 입력_생성("도기", "국민연금");
-        List<SaveDataRequest> 요청 = 요청_생성(input);
+        String input = 데이터_입력_생성("도기", "국민연금");
+        List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
         // when
         adminService.saveData(요청);
@@ -153,5 +156,18 @@ class AdminServiceTest {
                 "\t음식점네이버링크" +
                 "\t12.3456" +
                 "\t12.3456";
+    }
+
+    @Test
+    void 셀럽을_저장한다() {
+        // given
+        String input = 셀럽_입력_생성("도기");
+        List<SaveCelebRequest> 요청 = 셀럽_저장_요청_생성(input);
+
+        // when
+        adminService.saveCelebs(요청);
+
+        // then
+        assertThat(celebRepository.count()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
@@ -161,13 +161,19 @@ class AdminServiceTest {
     @Test
     void 셀럽을_저장한다() {
         // given
-        String input = 셀럽_입력_생성("도기");
+        List<Celeb> expected = List.of(셀럽("도기"), 셀럽("로이스"));
+        String input = 셀럽_입력_생성("도기")
+                + System.lineSeparator()
+                + 셀럽_입력_생성("로이스");
         List<SaveCelebRequest> 요청 = 셀럽_저장_요청_생성(input);
 
         // when
         adminService.saveCelebs(요청);
 
         // then
-        assertThat(celebRepository.count()).isEqualTo(1);
+        assertThat(celebRepository.count()).isEqualTo(2);
+        assertThat(celebRepository.findAll()).usingRecursiveComparison()
+                .comparingOnlyFields("name", "youtubeChannelName")
+                .isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## ✨ 요약
- `이름, 채널이름, 프로필사진URL` 형식으로 셀럽을 저장할 수 있는 API 구현
- AdminController에 `@Profile`을 추가해, 운영 환경에서는 api를 개방하지 않도록 함.

<br>

## 😎 해결한 이슈
- close #286

<br>
