### PR TITLE
feat: 주변 음식점 조회 api 구현

### DIFF
--- a/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/application/RestaurantQueryService.java
@@ -29,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,7 +176,7 @@ public class RestaurantQueryService {
                 .toList();
     }
 
-    public Page<RestaurantQueryResponse> findAllNearByDistance(
+    public Page<RestaurantQueryResponse> findAllNearByDistanceWithoutSpecificRestaurant(
             int distance,
             long restaurantId,
             Pageable pageable
@@ -202,6 +201,6 @@ public class RestaurantQueryService {
                 .filter(restaurantWithDistance -> restaurantWithDistance.name().equals(restaurant.name()))
                 .findFirst()
                 .ifPresent(newContent::remove);
-        return PageableExecutionUtils.getPage(newContent, pageable, restaurantsWithDistance::getTotalElements);
+        return new PageImpl<>(newContent, pageable, restaurantsWithDistance.getTotalElements());
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -89,8 +89,8 @@ public class RestaurantQueryRepository {
             FROM Restaurant r
             """;
 
-    private static final String WHERE_MIN_OR_EQUAL_DISTANCE_AND_NOT_SAME_RESTAURANT = """
-            WHERE %s <= %d AND id != %d
+    private static final String WHERE_MIN_OR_EQUAL_DISTANCE = """
+            WHERE %s <= %d
             """;
 
     private static final String COUNT_QUERY_NEARBY_DISTANCE = """
@@ -191,7 +191,7 @@ public class RestaurantQueryRepository {
             Pageable pageable
     ) {
         String dist = getDistanceColumn(restaurant.latitude(), restaurant.longitude());
-        String whereQuery = WHERE_MIN_OR_EQUAL_DISTANCE_AND_NOT_SAME_RESTAURANT.formatted(dist, distance, restaurant.id());
+        String whereQuery = WHERE_MIN_OR_EQUAL_DISTANCE.formatted(dist, distance);
         List<RestaurantWithDistance> result = em.createQuery(
                         SELECT_RESTAURANT_NEARBY_SPECIFIC_DISTANCE.formatted(dist)
                                 + whereQuery

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -74,6 +74,30 @@ public class RestaurantQueryRepository {
             ON c = v.celeb
             """;
 
+    private static final String SELECT_RESTAURANT_NEARBY_SPECIFIC_DISTANCE = """
+            SELECT new com.celuveat.restaurant.domain.dto.RestaurantWithDistance(
+                r.id,
+                r.name,
+                r.category,
+                r.roadAddress,
+                r.latitude,
+                r.longitude,
+                r.phoneNumber,
+                r.naverMapUrl,
+                %s AS dist
+            )
+            FROM Restaurant r
+            """;
+
+    private static final String WHERE_MIN_OR_EQUAL_DISTANCE_AND_NOT_SAME_RESTAURANT = """
+            WHERE %s <= %d AND id != %d
+            """;
+
+    private static final String COUNT_QUERY_NEARBY_DISTANCE = """
+            SELECT count(r)
+            FROM Restaurant r
+            """;
+
     private final EntityManager em;
 
     public Page<RestaurantWithDistance> getRestaurantsWithDistance(
@@ -159,5 +183,27 @@ public class RestaurantQueryRepository {
             Double lowLongitude,
             Double highLongitude
     ) {
+    }
+
+    public Page<RestaurantWithDistance> getRestaurantsWithDistanceNearBy(
+            int distance,
+            Restaurant restaurant,
+            Pageable pageable
+    ) {
+        String dist = getDistanceColumn(restaurant.latitude(), restaurant.longitude());
+        String whereQuery = WHERE_MIN_OR_EQUAL_DISTANCE_AND_NOT_SAME_RESTAURANT.formatted(dist, distance, restaurant.id());
+        List<RestaurantWithDistance> result = em.createQuery(
+                        SELECT_RESTAURANT_NEARBY_SPECIFIC_DISTANCE.formatted(dist)
+                                + whereQuery
+                                + ORDER_BY_DISTANCE_ASC,
+                        RestaurantWithDistance.class)
+                .setFirstResult((int) pageable.getOffset())
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+        return PageableExecutionUtils.getPage(
+                result,
+                pageable,
+                () -> (Long) em.createQuery(COUNT_QUERY_NEARBY_DISTANCE + whereQuery).getSingleResult()
+        );
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantQueryRepository.java
@@ -196,7 +196,8 @@ public class RestaurantQueryRepository {
                         SELECT_RESTAURANT_NEARBY_SPECIFIC_DISTANCE.formatted(dist)
                                 + whereQuery
                                 + ORDER_BY_DISTANCE_ASC,
-                        RestaurantWithDistance.class)
+                        RestaurantWithDistance.class
+                )
                 .setFirstResult((int) pageable.getOffset())
                 .setMaxResults(pageable.getPageSize())
                 .getResultList();

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
@@ -77,7 +77,7 @@ public class RestaurantController {
             @PathVariable Long restaurantId,
             @RequestParam(required = false, defaultValue = DEFAULT_DISTANCE) Integer distance
     ) {
-        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistance(
+        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistanceWithoutSpecificRestaurant(
                 distance,
                 restaurantId,
                 pageable

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
@@ -5,7 +5,6 @@ import com.celuveat.common.auth.Auth;
 import com.celuveat.restaurant.application.RestaurantLikeService;
 import com.celuveat.restaurant.application.RestaurantQueryFacade;
 import com.celuveat.restaurant.application.RestaurantQueryService;
-import com.celuveat.restaurant.application.RestaurantService;
 import com.celuveat.restaurant.application.dto.RestaurantDetailQueryResponse;
 import com.celuveat.restaurant.application.dto.RestaurantLikeQueryResponse;
 import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
@@ -32,8 +31,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class RestaurantController {
 
     private static final int DEFAULT_SIZE = 18;
+    private static final int NEARBY_DEFAULT_SIZE = 4;
+    private static final String DEFAULT_DISTANCE = "3000";
 
-    private final RestaurantService restaurantService;
     private final RestaurantLikeService restaurantLikeService;
     private final RestaurantQueryFacade restaurantQueryFacade;
     private final RestaurantQueryService restaurantQueryService;
@@ -69,5 +69,19 @@ public class RestaurantController {
             @RequestParam Long celebId
     ) {
         return ResponseEntity.ok(restaurantQueryFacade.findRestaurantDetailById(restaurantId, celebId));
+    }
+
+    @GetMapping("/{restaurantId}/nearby")
+    ResponseEntity<PageResponse<RestaurantQueryResponse>> findAllNearbyDistance(
+            @PageableDefault(size = NEARBY_DEFAULT_SIZE) Pageable pageable,
+            @PathVariable Long restaurantId,
+            @RequestParam(required = false, defaultValue = DEFAULT_DISTANCE) Integer distance
+    ) {
+        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistance(
+                distance,
+                restaurantId,
+                pageable
+        );
+        return ResponseEntity.ok(PageResponse.from(result));
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
@@ -92,14 +92,14 @@ public class RestaurantAcceptanceSteps {
         String restaurantName = (String) 음식점_이름;
         LocationSearchCond locationSearchCond = (LocationSearchCond) 검색_영역;
         for (RestaurantQueryResponse restaurantQueryResponse : 전체_음식점) {
-            List<Long> list = restaurantQueryResponse.celebs()
+            List<Long> celebIds = restaurantQueryResponse.celebs()
                     .stream()
                     .map(CelebQueryResponse::id)
                     .toList();
 
             if (음식점_이름_조건(restaurantName, restaurantQueryResponse)
                     && 카테고리_조건(category, restaurantQueryResponse)
-                    && 셀럽_조건(celebId, list)
+                    && 셀럽_조건(celebId, celebIds)
                     && 영역_조건(locationSearchCond, restaurantQueryResponse)) {
                 예상_응답.add(restaurantQueryResponse);
             }
@@ -241,5 +241,29 @@ public class RestaurantAcceptanceSteps {
         RestaurantDetailQueryResponse response = 응답.as(new TypeRef<>() {
         });
         assertThat(response.viewCount()).isEqualTo(예상_조회수);
+    }
+
+    public static ExtractableResponse<Response> 근처_음식점_조회_요청(Long 특정_음식점_ID, int 요청_거리) {
+        return given()
+                .queryParams("distance", 요청_거리)
+                .when().get("/api/restaurants/{restaurantId}/nearby", 특정_음식점_ID)
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 특정_거리_이내에_있는_음식점이며_기준이_되는_음식점은_포함하지_않는지_검증한다(
+            ExtractableResponse<Response> 요청_결과,
+            int 요청_거리,
+            long 기준_음식점_ID
+    ) {
+        PageResponse<RestaurantQueryResponse> pageResponse = 요청_결과.as(new TypeRef<>() {
+        });
+        assertThat(pageResponse.content())
+                .isSortedAccordingTo(comparing(RestaurantQueryResponse::distance))
+                .extracting("distance", Integer.class)
+                .allMatch(distance -> distance <= 요청_거리);
+        assertThat(pageResponse.content())
+                .extracting("id", Long.class)
+                .doesNotContain(기준_음식점_ID);
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
@@ -260,10 +260,10 @@ public class RestaurantAcceptanceSteps {
         });
         assertThat(pageResponse.content())
                 .isSortedAccordingTo(comparing(RestaurantQueryResponse::distance))
-                .extracting("distance", Integer.class)
+                .extracting(RestaurantQueryResponse::distance)
                 .allMatch(distance -> distance <= 요청_거리);
         assertThat(pageResponse.content())
-                .extracting("id", Long.class)
+                .extracting(RestaurantQueryResponse::id)
                 .doesNotContain(기준_음식점_ID);
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
@@ -6,6 +6,7 @@ import static com.celuveat.acceptance.celeb.CelebAcceptanceSteps.특정_이름�
 import static com.celuveat.acceptance.common.AcceptanceSteps.없음;
 import static com.celuveat.acceptance.common.AcceptanceSteps.잘못된_요청_예외를_검증한다;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.검색_영역;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.근처_음식점_조회_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.상세_조회_결과를_검증한다;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.상세_조회_예상_응답;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.예상_응답;
@@ -15,6 +16,7 @@ import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음�
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_상세_조회_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.조회_결과를_검증한다;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.조회수를_검증한다;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.특정_거리_이내에_있는_음식점이며_기준이_되는_음식점은_포함하지_않는지_검증한다;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.특정_이름의_음식점을_찾는다;
 import static com.celuveat.restaurant.fixture.LocationFixture.박스_1_2번_지점포함;
 import static com.celuveat.restaurant.fixture.LocationFixture.박스_1번_지점포함;
@@ -85,6 +87,21 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
 
             // then
             잘못된_요청_예외를_검증한다(응답);
+        }
+
+        @Test
+        void 특정_음식점을_기준으로_일정_거리_내에_있는_모든_음식점을_조회한다() {
+            // given
+            var 전체_음식점 = seedData.insertSeedData();
+            var 음식점 = 전체_음식점.get(0);
+            Long 음식점_ID = 음식점.id();
+            int 요청_거리 = 2000;
+
+            // when
+            var 요청_결과 = 근처_음식점_조회_요청(음식점_ID, 요청_거리);
+
+            // then
+            특정_거리_이내에_있는_음식점이며_기준이_되는_음식점은_포함하지_않는지_검증한다(요청_결과, 요청_거리, 음식점_ID);
         }
     }
 

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -455,7 +455,7 @@ class RestaurantQueryServiceTest {
         RestaurantQueryResponse restaurant = seed.get(0);
 
         // when
-        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistance(
+        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistanceWithoutSpecificRestaurant(
                 specificDistance,
                 restaurant.id(),
                 PageRequest.of(0, 4)

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -449,7 +449,7 @@ class RestaurantQueryServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {10, 50, 100, 500, 1000, 2000, 3000, 5000})
+    @ValueSource(ints = {10, 50, 100, 500, 1000, 2000, 3000, 5000, 30000})
     void 특정_음식점을_기준으로_일정_거리_내에_있는_모든_음식점_조회_테스트(int specificDistance) {
         // given
         RestaurantQueryResponse restaurant = seed.get(0);

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -379,8 +379,7 @@ class RestaurantQueryServiceTest {
                 음식점_좋아요(도기2호점, 멤버),
                 음식점_좋아요(로이스2호점, 멤버)
         ));
-        List<RestaurantLikeQueryResponse> expected = new ArrayList<>();
-        expected.addAll(List.of(
+        List<RestaurantLikeQueryResponse> expected = new ArrayList<>(List.of(
                 toRestaurantLikeQueryResponse(restaurantQueryResponse1),
                 toRestaurantLikeQueryResponse(restaurantQueryResponse2),
                 toRestaurantLikeQueryResponse(restaurantQueryResponse3),

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -445,5 +447,27 @@ class RestaurantQueryServiceTest {
                 restaurantQueryResponse.celebs(),
                 restaurantQueryResponse.images()
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 50, 100, 500, 1000, 2000, 3000, 5000})
+    void 특정_음식점을_기준으로_일정_거리_내에_있는_모든_음식점_조회_테스트(int specificDistance) {
+        // given
+        RestaurantQueryResponse restaurant = seed.get(0);
+
+        // when
+        Page<RestaurantQueryResponse> result = restaurantQueryService.findAllNearByDistance(
+                specificDistance,
+                restaurant.id(),
+                PageRequest.of(0, 4)
+        );
+
+        // then
+        assertThat(result.getContent())
+                .extracting("distance", Integer.class)
+                .allMatch(distance -> distance <= specificDistance);
+        assertThat(result.getContent())
+                .extracting("name", String.class)
+                .doesNotContain(restaurant.name());
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/application/RestaurantQueryServiceTest.java
@@ -463,10 +463,10 @@ class RestaurantQueryServiceTest {
 
         // then
         assertThat(result.getContent())
-                .extracting("distance", Integer.class)
+                .extracting(RestaurantQueryResponse::distance)
                 .allMatch(distance -> distance <= specificDistance);
         assertThat(result.getContent())
-                .extracting("name", String.class)
+                .extracting(RestaurantQueryResponse::name)
                 .doesNotContain(restaurant.name());
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import static com.celuveat.restaurant.fixture.LocationFixture.박스_1_2번_지�
 import static com.celuveat.restaurant.fixture.LocationFixture.박스_1번_지점포함;
 import static com.celuveat.restaurant.fixture.LocationFixture.전체영역_검색_범위;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.isCelebVisited;
+import static com.celuveat.restaurant.fixture.RestaurantFixture.국민연금_구내식당;
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -343,5 +346,27 @@ class RestaurantQueryRepositoryTest {
                 .isSortedAccordingTo(comparing(RestaurantWithDistance::distance))
                 .extracting(RestaurantWithDistance::name)
                 .containsExactlyInAnyOrderElementsOf(이름_추출(expected));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 100, 1000, 3000, 5000})
+    void 특정_음식점을_기준으로_일정_거리_내에_있는_모든_음식점_조회_테스트(int specificDistance) {
+        // given
+        Restaurant restaurant = 국민연금_구내식당;
+
+        // when
+        Page<RestaurantWithDistance> result = restaurantQueryRepository.getRestaurantsWithDistanceNearBy(
+                specificDistance,
+                restaurant,
+                PageRequest.of(0, 4)
+        );
+
+        // then
+        assertThat(result.getContent())
+                .extracting("distance", Double.class)
+                .allMatch(distance -> distance <= specificDistance);
+        assertThat(result.getContent())
+                .extracting("name", String.class)
+                .doesNotContain(restaurant.name());
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -360,7 +360,7 @@ class RestaurantQueryRepositoryTest {
 
         // then
         assertThat(result.getContent())
-                .extracting("distance", Double.class)
+                .extracting(RestaurantWithDistance::distance)
                 .allMatch(distance -> distance <= specificDistance);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -349,15 +349,12 @@ class RestaurantQueryRepositoryTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {10, 100, 1000, 3000, 5000})
+    @ValueSource(ints = {10, 100, 1000, 3000, 5000, 30000})
     void 특정_음식점을_기준으로_일정_거리_내에_있는_모든_음식점_조회_테스트(int specificDistance) {
-        // given
-        Restaurant restaurant = 국민연금_구내식당;
-
         // when
         Page<RestaurantWithDistance> result = restaurantQueryRepository.getRestaurantsWithDistanceNearBy(
                 specificDistance,
-                restaurant,
+                국민연금_구내식당,
                 PageRequest.of(0, 4)
         );
 
@@ -365,8 +362,5 @@ class RestaurantQueryRepositoryTest {
         assertThat(result.getContent())
                 .extracting("distance", Double.class)
                 .allMatch(distance -> distance <= specificDistance);
-        assertThat(result.getContent())
-                .extracting("name", String.class)
-                .doesNotContain(restaurant.name());
     }
 }


### PR DESCRIPTION
## ✨ 요약
1. **특정 음식점의 ID**와 **Optional한 값의 distance**(단위: m)를 받아, **해당 음식점 주변의 모든 음식점을 조회**하는 기능입니다.
2. **distance**는 **쿼리  파라미터**로 요청되며, 값이 입력되지 않으면 **default 3km**로 설정했습니다.
3. **페이징**으로 구현했으며, **한 페이지의 사이즈는 4**입니다.
4. 음식점들을 **거리순으로 정렬**하여 반환합니다.

<br>

## 😎 해결한 이슈
- close #280  

<br>
