### PR TITLE
feat: 음식점 및 셀럽으로 영상 조회 api 구현

### DIFF
--- a/backend/src/main/java/com/celuveat/celeb/exception/CelebException.java
+++ b/backend/src/main/java/com/celuveat/celeb/exception/CelebException.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CelebException extends BaseException {
 
-    private final BaseExceptionType exceptionType;
+    private final CelebExceptionType exceptionType;
 
     @Override
     public BaseExceptionType exceptionType() {

--- a/backend/src/main/java/com/celuveat/celeb/exception/CelebException.java
+++ b/backend/src/main/java/com/celuveat/celeb/exception/CelebException.java
@@ -1,0 +1,16 @@
+package com.celuveat.celeb.exception;
+
+import com.celuveat.common.exception.BaseException;
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CelebException extends BaseException {
+
+    private final BaseExceptionType exceptionType;
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/backend/src/main/java/com/celuveat/celeb/exception/CelebExceptionType.java
+++ b/backend/src/main/java/com/celuveat/celeb/exception/CelebExceptionType.java
@@ -1,0 +1,27 @@
+package com.celuveat.celeb.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CelebExceptionType implements BaseExceptionType {
+
+    NOT_FOUND_CELEB(BAD_REQUEST, "음식점을 찾을 수 없습니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/backend/src/main/java/com/celuveat/video/application/VideoQueryService.java
+++ b/backend/src/main/java/com/celuveat/video/application/VideoQueryService.java
@@ -1,0 +1,27 @@
+package com.celuveat.video.application;
+
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import com.celuveat.video.domain.VideoQueryRepository;
+import com.celuveat.video.domain.VideoQueryRepository.VideoSearchCond;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VideoQueryService {
+
+    private final VideoQueryRepository videoQueryRepository;
+
+    public Page<VideoWithCelebQueryResponse> findAllVideoWithCeleb(
+            VideoSearchCond videoSearchCond,
+            Pageable pageable
+    ) {
+        return videoQueryRepository.getVideosWithCeleb(
+                videoSearchCond, pageable
+        );
+    }
+}

--- a/backend/src/main/java/com/celuveat/video/application/dto/VideoWithCelebQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/video/application/dto/VideoWithCelebQueryResponse.java
@@ -1,4 +1,4 @@
-package com.celuveat.restaurant.application.dto;
+package com.celuveat.video.application.dto;
 
 import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.video.domain.Video;
@@ -13,7 +13,7 @@ public record VideoWithCelebQueryResponse(
         String youtubeChannelName,
         String profileImageUrl
 ) {
-    
+
     public static VideoWithCelebQueryResponse of(Video video) {
         Celeb celeb = video.celeb();
         return new VideoWithCelebQueryResponse(

--- a/backend/src/main/java/com/celuveat/video/application/dto/VideoWithCelebQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/video/application/dto/VideoWithCelebQueryResponse.java
@@ -1,7 +1,5 @@
 package com.celuveat.video.application.dto;
 
-import com.celuveat.celeb.domain.Celeb;
-import com.celuveat.video.domain.Video;
 import java.time.LocalDate;
 
 public record VideoWithCelebQueryResponse(
@@ -13,17 +11,4 @@ public record VideoWithCelebQueryResponse(
         String youtubeChannelName,
         String profileImageUrl
 ) {
-
-    public static VideoWithCelebQueryResponse of(Video video) {
-        Celeb celeb = video.celeb();
-        return new VideoWithCelebQueryResponse(
-                video.id(),
-                video.youtubeUrl(),
-                video.uploadDate(),
-                celeb.id(),
-                celeb.name(),
-                celeb.youtubeChannelName(),
-                celeb.profileImageUrl()
-        );
-    }
 }

--- a/backend/src/main/java/com/celuveat/video/domain/VideoQueryRepository.java
+++ b/backend/src/main/java/com/celuveat/video/domain/VideoQueryRepository.java
@@ -1,0 +1,91 @@
+package com.celuveat.video.domain;
+
+import static com.celuveat.common.query.DynamicQueryCondition.notNull;
+
+import com.celuveat.common.query.DynamicQuery;
+import com.celuveat.common.query.DynamicQueryAssembler;
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VideoQueryRepository {
+
+    private static final String SELECT_VIDEO = """
+            SELECT new com.celuveat.video.application.dto.VideoWithCelebQueryResponse(
+                v.id,
+                v.youtubeUrl,
+                v.uploadDate,
+                c.id,
+                c.name,
+                c.youtubeChannelName,
+                c.profileImageUrl
+            )
+            FROM Video v
+            JOIN Celeb c ON c = v.celeb
+            JOIN Restaurant r ON r = v.restaurant
+            """;
+    private static final String COUNT_QUERY = """
+            SELECT COUNT(DISTINCT v.id)
+            FROM Video v
+            JOIN Celeb c ON c = v.celeb
+            JOIN Restaurant r ON r = v.restaurant
+            """;
+    private static final String CELEB_ID_EQUAL = "c.id = %d";
+    private static final String RESTAURANT_ID_EQUAL = "r.id = %d";
+
+
+    private final EntityManager em;
+
+    public Page<VideoWithCelebQueryResponse> getVideosWithCeleb(
+            VideoSearchCond videoSearchCond,
+            Pageable pageable
+    ) {
+        String whereQuery = DynamicQueryAssembler.assemble(
+                celebIdEqual(videoSearchCond),
+                restaurantIdEqual(videoSearchCond)
+        );
+        List<VideoWithCelebQueryResponse> resultList = em.createQuery(
+                        SELECT_VIDEO + whereQuery,
+                        VideoWithCelebQueryResponse.class
+                )
+                .setFirstResult((int) pageable.getOffset())
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+        return PageableExecutionUtils.getPage(
+                resultList,
+                pageable,
+                () -> (Long) em.createQuery(COUNT_QUERY + whereQuery).getSingleResult()
+        );
+    }
+
+    private DynamicQuery celebIdEqual(VideoSearchCond videoSearchCond) {
+        return DynamicQuery.builder()
+                .query(CELEB_ID_EQUAL)
+                .params(videoSearchCond.celebId())
+                .condition(notNull(videoSearchCond.celebId()))
+                .build();
+    }
+
+    private DynamicQuery restaurantIdEqual(VideoSearchCond videoSearchCond) {
+        return DynamicQuery.builder()
+                .query(RESTAURANT_ID_EQUAL)
+                .params(videoSearchCond.restaurantId())
+                .condition(notNull(videoSearchCond.restaurantId()))
+                .build();
+    }
+
+    public record VideoSearchCond(
+            Long celebId,
+            Long restaurantId
+    ) {
+    }
+}

--- a/backend/src/main/java/com/celuveat/video/presentation/VideoController.java
+++ b/backend/src/main/java/com/celuveat/video/presentation/VideoController.java
@@ -1,0 +1,35 @@
+package com.celuveat.video.presentation;
+
+import com.celuveat.common.PageResponse;
+import com.celuveat.video.application.VideoQueryService;
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import com.celuveat.video.presentation.dto.VideoSearchCondRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/videos")
+public class VideoController {
+
+    private static final int VIDEO_WITH_CELEB_SIZE = 6;
+
+    private final VideoQueryService videoQueryService;
+
+    @GetMapping
+    ResponseEntity<PageResponse<VideoWithCelebQueryResponse>> getVideosByRestaurantId(
+            @PageableDefault(size = VIDEO_WITH_CELEB_SIZE) Pageable pageable,
+            @ModelAttribute VideoSearchCondRequest searchCondRequest
+    ) {
+        Page<VideoWithCelebQueryResponse> result =
+                videoQueryService.findAllVideoWithCeleb(searchCondRequest.toCondition(), pageable);
+        return ResponseEntity.ok(PageResponse.from(result));
+    }
+}

--- a/backend/src/main/java/com/celuveat/video/presentation/dto/VideoSearchCondRequest.java
+++ b/backend/src/main/java/com/celuveat/video/presentation/dto/VideoSearchCondRequest.java
@@ -8,9 +8,6 @@ public record VideoSearchCondRequest(
 ) {
 
     public VideoSearchCond toCondition() {
-        return new VideoSearchCond(
-                celebId,
-                restaurantId
-        );
+        return new VideoSearchCond(celebId, restaurantId);
     }
 }

--- a/backend/src/main/java/com/celuveat/video/presentation/dto/VideoSearchCondRequest.java
+++ b/backend/src/main/java/com/celuveat/video/presentation/dto/VideoSearchCondRequest.java
@@ -1,0 +1,16 @@
+package com.celuveat.video.presentation.dto;
+
+import com.celuveat.video.domain.VideoQueryRepository.VideoSearchCond;
+
+public record VideoSearchCondRequest(
+        Long celebId,
+        Long restaurantId
+) {
+
+    public VideoSearchCond toCondition() {
+        return new VideoSearchCond(
+                celebId,
+                restaurantId
+        );
+    }
+}

--- a/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
@@ -1,0 +1,76 @@
+package com.celuveat.acceptance.video;
+
+import static com.celuveat.acceptance.common.AcceptanceSteps.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.celeb.domain.Celeb;
+import com.celuveat.common.PageResponse;
+import com.celuveat.restaurant.domain.Restaurant;
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import com.celuveat.video.domain.Video;
+import com.celuveat.video.presentation.dto.VideoSearchCondRequest;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public class VideoAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 음식점ID로_영상_조회_요청(
+            VideoSearchCondRequest videoSearchCondRequest
+    ) {
+        Map<String, Object> param = new HashMap<>();
+        param.put("restaurantId", videoSearchCondRequest.restaurantId());
+        param.put("celebId", videoSearchCondRequest.celebId());
+        return given()
+                .queryParams(param)
+                .when().get("/api/videos")
+                .then().log().all()
+                .extract();
+    }
+
+    public static Restaurant 특정_이름의_음식점을_찾는다(List<Video> 영상들, String 음식점_이름) {
+        return 영상들.stream()
+                .map(Video::restaurant)
+                .filter(restaurant -> restaurant.name().equals(음식점_이름))
+                .findAny()
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    public static List<Video> 특정_음식점의_영상을_추출한다(List<Video> 영상들, Restaurant 음식점) {
+        return 영상들.stream()
+                .filter(video -> video.restaurant().id().equals(음식점.id()))
+                .toList();
+    }
+
+    public static Celeb 특정_이름의_셀럽을_찾는다(List<Video> 영상들, String 셀럽_이름) {
+        return 영상들.stream()
+                .map(Video::celeb)
+                .filter(celeb -> celeb.name().equals(셀럽_이름))
+                .findAny()
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    public static List<Video> 특정_셀럽의_영상을_추출한다(List<Video> 영상들, Celeb 셀럽) {
+        return 영상들.stream()
+                .filter(video -> video.celeb().id().equals(셀럽.id()))
+                .toList();
+    }
+
+    public static List<VideoWithCelebQueryResponse> 영상_조회_예상_응답(List<Video> 영상들) {
+        return 영상들.stream()
+                .map(VideoWithCelebQueryResponse::of)
+                .toList();
+    }
+
+    public static void 영상_응답_결과를_검증한다(List<VideoWithCelebQueryResponse> 예상_응답, ExtractableResponse<Response> 응답) {
+        PageResponse<VideoWithCelebQueryResponse> response = 응답.as(new TypeRef<>() {
+        });
+        assertThat(response.content())
+                .usingRecursiveComparison()
+                .isEqualTo(예상_응답);
+    }
+}

--- a/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
@@ -1,11 +1,15 @@
 package com.celuveat.acceptance.video;
 
 import static com.celuveat.acceptance.common.AcceptanceSteps.given;
+import static com.celuveat.celeb.exception.CelebExceptionType.NOT_FOUND_CELEB;
+import static com.celuveat.restaurant.exception.RestaurantExceptionType.NOT_FOUND_RESTAURANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.celuveat.celeb.domain.Celeb;
+import com.celuveat.celeb.exception.CelebException;
 import com.celuveat.common.PageResponse;
 import com.celuveat.restaurant.domain.Restaurant;
+import com.celuveat.restaurant.exception.RestaurantException;
 import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
 import com.celuveat.video.domain.Video;
 import com.celuveat.video.presentation.dto.VideoSearchCondRequest;
@@ -15,7 +19,6 @@ import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 public class VideoAcceptanceSteps {
 
@@ -37,7 +40,7 @@ public class VideoAcceptanceSteps {
                 .map(Video::restaurant)
                 .filter(restaurant -> restaurant.name().equals(음식점_이름))
                 .findAny()
-                .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(() -> new RestaurantException(NOT_FOUND_RESTAURANT));
     }
 
     public static List<Video> 특정_음식점의_영상을_추출한다(List<Video> 영상들, Restaurant 음식점) {
@@ -51,7 +54,7 @@ public class VideoAcceptanceSteps {
                 .map(Video::celeb)
                 .filter(celeb -> celeb.name().equals(셀럽_이름))
                 .findAny()
-                .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(() -> new CelebException(NOT_FOUND_CELEB));
     }
 
     public static List<Video> 특정_셀럽의_영상을_추출한다(List<Video> 영상들, Celeb 셀럽) {

--- a/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceSteps.java
@@ -65,7 +65,7 @@ public class VideoAcceptanceSteps {
 
     public static List<VideoWithCelebQueryResponse> 영상_조회_예상_응답(List<Video> 영상들) {
         return 영상들.stream()
-                .map(VideoWithCelebQueryResponse::of)
+                .map(VideoAcceptanceSteps::toVideoWithCelebQueryResponse)
                 .toList();
     }
 
@@ -75,5 +75,18 @@ public class VideoAcceptanceSteps {
         assertThat(response.content())
                 .usingRecursiveComparison()
                 .isEqualTo(예상_응답);
+    }
+
+    private static VideoWithCelebQueryResponse toVideoWithCelebQueryResponse(Video video) {
+        Celeb celeb = video.celeb();
+        return new VideoWithCelebQueryResponse(
+                video.id(),
+                video.youtubeUrl(),
+                video.uploadDate(),
+                celeb.id(),
+                celeb.name(),
+                celeb.youtubeChannelName(),
+                celeb.profileImageUrl()
+        );
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceTest.java
@@ -21,7 +21,7 @@ public class VideoAcceptanceTest extends AcceptanceTest {
     private SeedData seedData;
 
     @Test
-    void 영상을_전쳬_조회한다() {
+    void 영상을_전체_조회한다() {
         // given
         var 전체_영상 = seedData.insertVideoSeedData();
         var 예상_응답 = 영상_조회_예상_응답(전체_영상);

--- a/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/video/VideoAcceptanceTest.java
@@ -1,0 +1,81 @@
+package com.celuveat.acceptance.video;
+
+import static com.celuveat.acceptance.common.AcceptanceSteps.없음;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.영상_응답_결과를_검증한다;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.영상_조회_예상_응답;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.음식점ID로_영상_조회_요청;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.특정_셀럽의_영상을_추출한다;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.특정_음식점의_영상을_추출한다;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.특정_이름의_셀럽을_찾는다;
+import static com.celuveat.acceptance.video.VideoAcceptanceSteps.특정_이름의_음식점을_찾는다;
+
+import com.celuveat.acceptance.common.AcceptanceTest;
+import com.celuveat.common.SeedData;
+import com.celuveat.video.presentation.dto.VideoSearchCondRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class VideoAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private SeedData seedData;
+
+    @Test
+    void 영상을_전쳬_조회한다() {
+        // given
+        var 전체_영상 = seedData.insertVideoSeedData();
+        var 예상_응답 = 영상_조회_예상_응답(전체_영상);
+
+        // when
+        var 응답 = 음식점ID로_영상_조회_요청(new VideoSearchCondRequest((Long) 없음, (Long) 없음));
+
+        // then
+        영상_응답_결과를_검증한다(예상_응답, 응답);
+    }
+
+    @Test
+    void 음식점ID로_영상을_조회한다() {
+        // given
+        var 전체_영상 = seedData.insertVideoSeedData();
+        var 로이스1호점 = 특정_이름의_음식점을_찾는다(전체_영상, "로이스1호점");
+        var 영상들 = 특정_음식점의_영상을_추출한다(전체_영상, 로이스1호점);
+        var 예상_응답 = 영상_조회_예상_응답(영상들);
+
+        // when
+        var 응답 = 음식점ID로_영상_조회_요청(new VideoSearchCondRequest((Long) 없음, 로이스1호점.id()));
+
+        // then
+        영상_응답_결과를_검증한다(예상_응답, 응답);
+    }
+
+    @Test
+    void 셀럽ID로_영상을_조회한다() {
+        // given
+        var 전체_영상 = seedData.insertVideoSeedData();
+        var 로이스 = 특정_이름의_셀럽을_찾는다(전체_영상, "로이스");
+        var 영상들 = 특정_셀럽의_영상을_추출한다(전체_영상, 로이스);
+        var 예상_응답 = 영상_조회_예상_응답(영상들);
+
+        // when
+        var 응답 = 음식점ID로_영상_조회_요청(new VideoSearchCondRequest(로이스.id(), (Long) 없음));
+
+        // then
+        영상_응답_결과를_검증한다(예상_응답, 응답);
+    }
+
+    @Test
+    void 음식점ID와_셀럽ID로_영상을_조회한다() {
+        // given
+        var 전체_영상 = seedData.insertVideoSeedData();
+        var 로이스1호점 = 특정_이름의_음식점을_찾는다(전체_영상, "로이스1호점");
+        var 영상들 = 특정_음식점의_영상을_추출한다(전체_영상, 로이스1호점);
+        var 로이스 = 특정_이름의_셀럽을_찾는다(영상들, "로이스");
+        var 예상_응답 = 영상_조회_예상_응답(특정_셀럽의_영상을_추출한다(영상들, 로이스));
+
+        // when
+        var 응답 = 음식점ID로_영상_조회_요청(new VideoSearchCondRequest(로이스.id(), 로이스1호점.id()));
+
+        // then
+        영상_응답_결과를_검증한다(예상_응답, 응답);
+    }
+}

--- a/backend/src/test/java/com/celuveat/common/SeedData.java
+++ b/backend/src/test/java/com/celuveat/common/SeedData.java
@@ -7,16 +7,15 @@ import static com.celuveat.restaurant.fixture.RestaurantFixture.음식점;
 import static com.celuveat.restaurant.fixture.RestaurantImageFixture.음식점사진;
 import static com.celuveat.video.fixture.VideoFixture.영상;
 
-import com.celuveat.auth.domain.OauthMemberRepository;
 import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.celeb.domain.CelebRepository;
 import com.celuveat.restaurant.application.dto.RestaurantQueryResponse;
 import com.celuveat.restaurant.domain.Restaurant;
 import com.celuveat.restaurant.domain.RestaurantImage;
 import com.celuveat.restaurant.domain.RestaurantImageRepository;
-import com.celuveat.restaurant.domain.RestaurantLikeRepository;
 import com.celuveat.restaurant.domain.RestaurantRepository;
 import com.celuveat.restaurant.domain.dto.RestaurantWithDistance;
+import com.celuveat.video.domain.Video;
 import com.celuveat.video.domain.VideoRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +30,6 @@ public class SeedData {
     private final CelebRepository celebRepository;
     private final RestaurantRepository restaurantRepository;
     private final RestaurantImageRepository restaurantImageRepository;
-    private final RestaurantLikeRepository restaurantLikeRepository;
-    private final OauthMemberRepository oauthMemberRepository;
     private final VideoRepository videoRepository;
 
     public List<RestaurantQueryResponse> insertSeedData() {
@@ -178,6 +175,23 @@ public class SeedData {
                 restaurant.phoneNumber(),
                 restaurant.naverMapUrl(),
                 distance
+        );
+    }
+
+    public List<Video> insertVideoSeedData() {
+        Restaurant 로이스1호점 = restaurantRepository.save(음식점("로이스1호점"));
+        Restaurant 로이스2호점 = restaurantRepository.save(음식점("로이스2호점"));
+        Celeb 로이스 = 셀럽("로이스");
+        Celeb 도기 = 셀럽("도기");
+        Celeb 말랑 = 셀럽("말랑");
+        Celeb 오도 = 셀럽("오도");
+        celebRepository.saveAll(List.of(로이스, 도기, 말랑, 오도));
+        return videoRepository.saveAll(List.of(
+                        영상("ww.comA", 로이스1호점, 로이스),
+                        영상("ww.comB", 로이스1호점, 도기),
+                        영상("ww.comC", 로이스2호점, 말랑),
+                        영상("ww.comD", 로이스2호점, 오도)
+                )
         );
     }
 }

--- a/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
@@ -21,8 +21,7 @@ import org.springframework.data.domain.PageRequest;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @DisplayName("영상 조회용 Repo(VideoQueryRepository) 은(는)")
 class VideoQueryServiceTest {
-
-
+    
     @Autowired
     private SeedData seedData;
 

--- a/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
@@ -1,0 +1,123 @@
+package com.celuveat.video.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.common.IntegrationTest;
+import com.celuveat.common.SeedData;
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import com.celuveat.video.domain.Video;
+import com.celuveat.video.domain.VideoQueryRepository.VideoSearchCond;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@IntegrationTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("영상 조회용 Repo(VideoQueryRepository) 은(는)")
+class VideoQueryServiceTest {
+
+
+    @Autowired
+    private SeedData seedData;
+
+    @Autowired
+    private VideoQueryService videoQueryService;
+
+    @Nested
+    class 영상_검색 {
+
+        @Test
+        void 영상_전체_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryService.findAllVideoWithCeleb(
+                    new VideoSearchCond(null, null),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 음식점ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedRestaurantId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryService.findAllVideoWithCeleb(
+                    new VideoSearchCond(null, expectedRestaurantId),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 셀럽ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedCelebId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.celeb().id().equals(expectedCelebId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryService.findAllVideoWithCeleb(
+                    new VideoSearchCond(expectedCelebId, null),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 음식점ID와_셀럽ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedRestaurantId = 1L;
+            Long expectedCelebId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
+                    .filter(video -> video.celeb().id().equals(expectedCelebId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryService.findAllVideoWithCeleb(
+                    new VideoSearchCond(expectedCelebId, expectedRestaurantId),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+}

--- a/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.celuveat.video.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.common.IntegrationTest;
 import com.celuveat.common.SeedData;
 import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
@@ -36,7 +37,7 @@ class VideoQueryServiceTest {
             // given
             List<Video> videos = seedData.insertVideoSeedData();
             List<VideoWithCelebQueryResponse> expected = videos.stream()
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -58,7 +59,7 @@ class VideoQueryServiceTest {
             Long expectedRestaurantId = 1L;
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -80,7 +81,7 @@ class VideoQueryServiceTest {
             Long expectedCelebId = 1L;
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.celeb().id().equals(expectedCelebId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -104,7 +105,7 @@ class VideoQueryServiceTest {
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
                     .filter(video -> video.celeb().id().equals(expectedCelebId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -117,6 +118,19 @@ class VideoQueryServiceTest {
             assertThat(result.getContent())
                     .usingRecursiveComparison()
                     .isEqualTo(expected);
+        }
+
+        private VideoWithCelebQueryResponse toVideoWithCelebQueryResponse(Video video) {
+            Celeb celeb = video.celeb();
+            return new VideoWithCelebQueryResponse(
+                    video.id(),
+                    video.youtubeUrl(),
+                    video.uploadDate(),
+                    celeb.id(),
+                    celeb.name(),
+                    celeb.youtubeChannelName(),
+                    celeb.profileImageUrl()
+            );
         }
     }
 }

--- a/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/video/application/VideoQueryServiceTest.java
@@ -19,9 +19,9 @@ import org.springframework.data.domain.PageRequest;
 
 @IntegrationTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@DisplayName("영상 조회용 Repo(VideoQueryRepository) 은(는)")
+@DisplayName("영상 조회용 서비스(VideoQueryService) 은(는)")
 class VideoQueryServiceTest {
-    
+
     @Autowired
     private SeedData seedData;
 

--- a/backend/src/test/java/com/celuveat/video/domain/VideoQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/video/domain/VideoQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.celuveat.video.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.celuveat.celeb.domain.Celeb;
 import com.celuveat.common.IntegrationTest;
 import com.celuveat.common.SeedData;
 import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
@@ -35,7 +36,7 @@ class VideoQueryRepositoryTest {
             // given
             List<Video> videos = seedData.insertVideoSeedData();
             List<VideoWithCelebQueryResponse> expected = videos.stream()
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -57,7 +58,7 @@ class VideoQueryRepositoryTest {
             Long expectedRestaurantId = 1L;
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -79,7 +80,7 @@ class VideoQueryRepositoryTest {
             Long expectedCelebId = 1L;
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.celeb().id().equals(expectedCelebId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -103,7 +104,7 @@ class VideoQueryRepositoryTest {
             List<VideoWithCelebQueryResponse> expected = videos.stream()
                     .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
                     .filter(video -> video.celeb().id().equals(expectedCelebId))
-                    .map(VideoWithCelebQueryResponse::of)
+                    .map(this::toVideoWithCelebQueryResponse)
                     .toList();
 
             // when
@@ -116,6 +117,19 @@ class VideoQueryRepositoryTest {
             assertThat(result.getContent())
                     .usingRecursiveComparison()
                     .isEqualTo(expected);
+        }
+
+        private VideoWithCelebQueryResponse toVideoWithCelebQueryResponse(Video video) {
+            Celeb celeb = video.celeb();
+            return new VideoWithCelebQueryResponse(
+                    video.id(),
+                    video.youtubeUrl(),
+                    video.uploadDate(),
+                    celeb.id(),
+                    celeb.name(),
+                    celeb.youtubeChannelName(),
+                    celeb.profileImageUrl()
+            );
         }
     }
 }

--- a/backend/src/test/java/com/celuveat/video/domain/VideoQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/video/domain/VideoQueryRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.celuveat.video.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.common.IntegrationTest;
+import com.celuveat.common.SeedData;
+import com.celuveat.video.application.dto.VideoWithCelebQueryResponse;
+import com.celuveat.video.domain.VideoQueryRepository.VideoSearchCond;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@IntegrationTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("영상 조회용 Repo(VideoQueryRepository) 은(는)")
+class VideoQueryRepositoryTest {
+
+    @Autowired
+    private SeedData seedData;
+
+    @Autowired
+    private VideoQueryRepository videoQueryRepository;
+
+    @Nested
+    class 영상_검색 {
+
+        @Test
+        void 영상_전체_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryRepository.getVideosWithCeleb(
+                    new VideoSearchCond(null, null),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 음식점ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedRestaurantId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryRepository.getVideosWithCeleb(
+                    new VideoSearchCond(null, expectedRestaurantId),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 셀럽ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedCelebId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.celeb().id().equals(expectedCelebId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryRepository.getVideosWithCeleb(
+                    new VideoSearchCond(expectedCelebId, null),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 음식점ID와_셀럽ID로_영상_검색() {
+            // given
+            List<Video> videos = seedData.insertVideoSeedData();
+            Long expectedRestaurantId = 1L;
+            Long expectedCelebId = 1L;
+            List<VideoWithCelebQueryResponse> expected = videos.stream()
+                    .filter(video -> video.restaurant().id().equals(expectedRestaurantId))
+                    .filter(video -> video.celeb().id().equals(expectedCelebId))
+                    .map(VideoWithCelebQueryResponse::of)
+                    .toList();
+
+            // when
+            Page<VideoWithCelebQueryResponse> result = videoQueryRepository.getVideosWithCeleb(
+                    new VideoSearchCond(expectedCelebId, expectedRestaurantId),
+                    PageRequest.of(0, expected.size())
+            );
+
+            // then
+            assertThat(result.getContent())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 요약
```
`VideoSearchCond` 를 통해 조건(음식점, 셀럽)에 따른 영상 조회 API 구현
```
<br>

- #282 와 관련된 [commits](https://github.com/woowacourse-teams/2023-celuveat/pull/299/files/69d59dc451a20461fbf591a6dc67f263e8231532..10a75212acfc86d5cad778a398d16b66785f6dbc)
-> note: #292 Merge 이후 rebase가 필요합니다.

## 😎 해결한 이슈
- close #282 
