### PR TITLE
feat: 카카오 oauth 회원탈퇴 api 구현

### DIFF
--- a/backend/src/main/java/com/celuveat/auth/application/OauthService.java
+++ b/backend/src/main/java/com/celuveat/auth/application/OauthService.java
@@ -32,7 +32,7 @@ public class OauthService {
         oauthMemberClientComposite.logout(oauthServerType, oauthMember.oauthId());
     }
 
-    public void withDraw(OauthServerType oauthServerType, Long oauthMemberId) {
+    public void withdraw(OauthServerType oauthServerType, Long oauthMemberId) {
         OauthMember oauthMember = oauthMemberRepository.getById(oauthMemberId);
         oauthMemberClientComposite.withDraw(oauthServerType, oauthMember.oauthId());
     }

--- a/backend/src/main/java/com/celuveat/auth/application/OauthService.java
+++ b/backend/src/main/java/com/celuveat/auth/application/OauthService.java
@@ -31,4 +31,9 @@ public class OauthService {
         OauthMember oauthMember = oauthMemberRepository.getById(oauthMemberId);
         oauthMemberClientComposite.logout(oauthServerType, oauthMember.oauthId());
     }
+
+    public void withDraw(OauthServerType oauthServerType, Long oauthMemberId) {
+        OauthMember oauthMember = oauthMemberRepository.getById(oauthMemberId);
+        oauthMemberClientComposite.withDraw(oauthServerType, oauthMember.oauthId());
+    }
 }

--- a/backend/src/main/java/com/celuveat/auth/application/OauthService.java
+++ b/backend/src/main/java/com/celuveat/auth/application/OauthService.java
@@ -27,8 +27,8 @@ public class OauthService {
         return saved.id();
     }
 
-    public void logout(OauthServerType oauthServerType, Long oauthServerId) {
-        OauthMember oauthMember = oauthMemberRepository.getById(oauthServerId);
+    public void logout(OauthServerType oauthServerType, Long oauthMemberId) {
+        OauthMember oauthMember = oauthMemberRepository.getById(oauthMemberId);
         oauthMemberClientComposite.logout(oauthServerType, oauthMember.oauthId());
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/domain/OauthId.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/OauthId.java
@@ -14,15 +14,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class OauthId {
 
-    @Column(nullable = false, name = "oauth_server_id")
-    private String oauthServerId;
+    @Column(nullable = false, name = "oauth_server_member_id")
+    private String oauthServerMemberId;
 
     @Enumerated(STRING)
     @Column(nullable = false, name = "oauth_server")
     private OauthServerType oauthServerType;
 
-    public String oauthServerId() {
-        return oauthServerId;
+    public String oauthServerMemberId() {
+        return oauthServerMemberId;
     }
 
     public OauthServerType oauthServer() {

--- a/backend/src/main/java/com/celuveat/auth/domain/OauthMember.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/OauthMember.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
                 @UniqueConstraint(
                         name = "oauth_id_unique",
                         columnNames = {
-                                "oauth_server_id",
+                                "oauth_server_member_id",
                                 "oauth_server"
                         }
                 ),

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
@@ -10,4 +10,6 @@ public interface OauthMemberClient {
     OauthMember fetch(String code);
 
     void logout(String oauthServerId);
+
+    void withDraw(String oauthServerId);
 }

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
@@ -9,7 +9,7 @@ public interface OauthMemberClient {
 
     OauthMember fetch(String code);
 
-    void logout(String oauthServerId);
+    void logout(String oauthServerMemberId);
 
-    void withDraw(String oauthServerId);
+    void withDraw(String oauthServerMemberId);
 }

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
@@ -31,6 +31,10 @@ public class OauthMemberClientComposite {
         getClient(oauthServerType).logout(oauthId.oauthServerId());
     }
 
+    public void withDraw(OauthServerType oauthServerType, OauthId oauthId) {
+        getClient(oauthServerType).withDraw(oauthId.oauthServerId());
+    }
+
     private OauthMemberClient getClient(OauthServerType oauthServerType) {
         return Optional.ofNullable(clients.get(oauthServerType))
                 .orElseThrow(() -> new AuthException(UNSUPPORTED_OAUTH_TYPE));

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
@@ -20,10 +20,7 @@ public class OauthMemberClientComposite {
 
     public OauthMemberClientComposite(Set<OauthMemberClient> clients) {
         this.clients = clients.stream()
-                .collect(toMap(
-                        OauthMemberClient::supportServer,
-                        identity()
-                ));
+                .collect(toMap(OauthMemberClient::supportServer, identity()));
     }
 
     public OauthMember fetch(OauthServerType oauthServerType, String authCode) {

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
@@ -28,11 +28,11 @@ public class OauthMemberClientComposite {
     }
 
     public void logout(OauthServerType oauthServerType, OauthId oauthId) {
-        getClient(oauthServerType).logout(oauthId.oauthServerId());
+        getClient(oauthServerType).logout(oauthId.oauthServerMemberId());
     }
 
     public void withDraw(OauthServerType oauthServerType, OauthId oauthId) {
-        getClient(oauthServerType).withDraw(oauthId.oauthServerId());
+        getClient(oauthServerType).withDraw(oauthId.oauthServerMemberId());
     }
 
     private OauthMemberClient getClient(OauthServerType oauthServerType) {

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
@@ -42,10 +42,10 @@ public class GoogleMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void logout(String oauthServerId) {
+    public void logout(String oauthServerMemberId) {
     }
 
     @Override
-    public void withDraw(String oauthServerId) {
+    public void withDraw(String oauthServerMemberId) {
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
@@ -44,4 +44,8 @@ public class GoogleMemberClient implements OauthMemberClient {
     @Override
     public void logout(String oauthServerId) {
     }
+
+    @Override
+    public void withDraw(String oauthServerId) {
+    }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
@@ -3,7 +3,6 @@ package com.celuveat.auth.infra.oauth.kakao.client;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
-import com.celuveat.auth.infra.oauth.kakao.dto.KakaoLogoutResponse;
 import com.celuveat.auth.infra.oauth.kakao.dto.KakaoMemberResponse;
 import com.celuveat.auth.infra.oauth.kakao.dto.KakaoToken;
 import org.springframework.util.MultiValueMap;
@@ -18,11 +17,11 @@ public interface KakaoApiClient {
     @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
     KakaoToken fetchToken(@RequestParam MultiValueMap<String, String> params);
 
-    @GetExchange("https://kapi.kakao.com/v2/user/me")
+    @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
     KakaoMemberResponse fetchMember(@RequestHeader(name = AUTHORIZATION) String accessToken);
 
     @PostExchange(url = "https://kapi.kakao.com/v1/user/logout")
-    KakaoLogoutResponse logoutMember(
+    void logoutMember(
             @RequestHeader(name = AUTHORIZATION) String adminKey,
             @RequestBody MultiValueMap<String, String> params
     );

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
@@ -25,4 +25,10 @@ public interface KakaoApiClient {
             @RequestHeader(name = AUTHORIZATION) String adminKey,
             @RequestBody MultiValueMap<String, String> params
     );
+
+    @PostExchange(url = "https://kapi.kakao.com/v1/user/unlink")
+    void withDrawMember(
+            @RequestHeader(name = AUTHORIZATION) String adminKey,
+            @RequestBody MultiValueMap<String, String> params
+    );
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
@@ -42,18 +42,18 @@ public class KakaoMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void logout(String oauthServerId) {
+    public void logout(String oauthServerMemberId) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("target_id_type", "user_id");
-        params.add("target_id", oauthServerId);
+        params.add("target_id", oauthServerMemberId);
         kakaoApiClient.logoutMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
     }
 
     @Override
-    public void withDraw(String oauthServerId) {
+    public void withDraw(String oauthServerMemberId) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("target_id_type", "user_id");
-        params.add("target_id", oauthServerId);
+        params.add("target_id", oauthServerMemberId);
         kakaoApiClient.withDrawMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
@@ -48,4 +48,12 @@ public class KakaoMemberClient implements OauthMemberClient {
         params.add("target_id", oauthServerId);
         kakaoApiClient.logoutMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
     }
+
+    @Override
+    public void withDraw(String oauthServerId) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", oauthServerId);
+        kakaoApiClient.withDrawMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
+    }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
@@ -43,16 +43,9 @@ public class KakaoMemberClient implements OauthMemberClient {
 
     @Override
     public void logout(String oauthServerId) {
-        kakaoApiClient.logoutMember(
-                "KakaoAK " + kakaoOauthConfig.adminKey(),
-                logoutRequestParams(oauthServerId)
-        );
-    }
-
-    private MultiValueMap<String, String> logoutRequestParams(String oauthServerId) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("target_id_type", "user_id");
         params.add("target_id", oauthServerId);
-        return params;
+        kakaoApiClient.logoutMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/dto/KakaoLogoutResponse.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/dto/KakaoLogoutResponse.java
@@ -1,6 +1,0 @@
-package com.celuveat.auth.infra.oauth.kakao.dto;
-
-public record KakaoLogoutResponse(
-        Long id
-) {
-}

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
@@ -43,4 +43,8 @@ public class NaverMemberClient implements OauthMemberClient {
     @Override
     public void logout(String oauthServerId) {
     }
+
+    @Override
+    public void withDraw(String oauthServerId) {
+    }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
@@ -41,10 +41,10 @@ public class NaverMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void logout(String oauthServerId) {
+    public void logout(String oauthServerMemberId) {
     }
 
     @Override
-    public void withDraw(String oauthServerId) {
+    public void withDraw(String oauthServerMemberId) {
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
+++ b/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
@@ -59,19 +59,19 @@ public class OauthController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/withdraw/{oauthServerType}")
-    ResponseEntity<Void> withdraw(@PathVariable OauthServerType oauthServerType, HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
-        Long oauthMemberId = getOauthMemberId(session);
-        oauthService.withDraw(oauthServerType, oauthMemberId);
-        session.invalidate();
-        return ResponseEntity.noContent().build();
-    }
-
     private Long getOauthMemberId(HttpSession session) {
         if (session == null) {
             throw new AuthException(UNAUTHORIZED_REQUEST);
         }
         return (Long) session.getAttribute(JSESSION_ID);
+    }
+
+    @DeleteMapping("/withdraw/{oauthServerType}")
+    ResponseEntity<Void> withdraw(@PathVariable OauthServerType oauthServerType, HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        Long oauthMemberId = getOauthMemberId(session);
+        oauthService.withdraw(oauthServerType, oauthMemberId);
+        session.invalidate();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
+++ b/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
@@ -50,17 +50,18 @@ public class OauthController {
     }
 
     @GetMapping("/logout/{oauthServerType}")
-    ResponseEntity<Void> logout(
-            @PathVariable OauthServerType oauthServerType,
-            HttpServletRequest request
-    ) {
+    ResponseEntity<Void> logout(@PathVariable OauthServerType oauthServerType, HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session == null) {
-            throw new AuthException(UNAUTHORIZED_REQUEST);
-        }
-        Long oauthMemberId = (Long) session.getAttribute(JSESSION_ID);
+        Long oauthMemberId = getOauthMemberId(session);
         oauthService.logout(oauthServerType, oauthMemberId);
         session.invalidate();
         return ResponseEntity.noContent().build();
+    }
+
+    private Long getOauthMemberId(HttpSession session) {
+        if (session == null) {
+            throw new AuthException(UNAUTHORIZED_REQUEST);
+        }
+        return (Long) session.getAttribute(JSESSION_ID);
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
+++ b/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,6 +55,15 @@ public class OauthController {
         HttpSession session = request.getSession(false);
         Long oauthMemberId = getOauthMemberId(session);
         oauthService.logout(oauthServerType, oauthMemberId);
+        session.invalidate();
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/withdraw/{oauthServerType}")
+    ResponseEntity<Void> withdraw(@PathVariable OauthServerType oauthServerType, HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        Long oauthMemberId = getOauthMemberId(session);
+        oauthService.withDraw(oauthServerType, oauthMemberId);
         session.invalidate();
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## ✨ 요약
1. 카카오 로그아웃 API 기능 관련 메서드 리팩터링
  - 불필요한 반환 제거
  - 개행 스타일 변경
  - 혼란을 야기할 변수명 수정
2. 카카오 회원탈퇴 API 구현

## ❗️ Note
필드명 변경되었습니다.
`oauth_member` 테이블의 `oauth_server_id`를 `oauth_server_member_id`로 변경되었습니다.

<br>

## 😎 해결한 이슈
- close #300 

## 😎 관련한 이슈
- #301 

<br>
