### PR TITLE
feat: 회원 탈퇴 기능 및 위시리스트 명세에 맞게 기능 수정

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import type { Preview } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GlobalStyles from '../src/styles/GlobalStyles';
 import { BrowserRouter } from 'react-router-dom';
+
+const queryClient = new QueryClient();
 
 const preview: Preview = {
   parameters: {
@@ -19,9 +22,11 @@ export const decorators = [
   Story => (
     <>
       <GlobalStyles />
-      <BrowserRouter>
-        <Story />
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Story />
+        </BrowserRouter>
+      </QueryClientProvider>
     </>
   ),
 ];

--- a/frontend/src/@types/api.types.ts
+++ b/frontend/src/@types/api.types.ts
@@ -24,6 +24,8 @@ export interface RestaurantData {
   images: { id: number; name: string; author: string; sns: string }[];
 }
 
+export type RestaurantWishData = Omit<RestaurantData, 'isLiked'>;
+
 export interface ProfileData {
   nickname: string;
   profileImageUrl: string;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import MainPage from '~/pages/MainPage';
 import RestaurantDetail from './pages/RestaurantDetail';
 import WishListPage from '~/pages/WishListPage';
 import SignUpPage from '~/pages/SignUpPage';
+import WithdrawalPage from '~/pages/WithdrawalPage';
 
 export const { BASE_URL } = process.env;
 
@@ -14,10 +15,11 @@ function App() {
         <Route path="/" element={<MainPage />} />
         <Route path="/restaurants/:id" element={<RestaurantDetail />} />
         <Route path="/signUp" element={<SignUpPage />} />
+        <Route path="/restaurants/like" element={<WishListPage />} />
+        <Route path="/withdrawal" element={<WithdrawalPage />} />
         <Route path="/oauth/redirect/kakao" element={<OauthRedirectPage type="kakao" />} />
         <Route path="/oauth/redirect/naver" element={<OauthRedirectPage type="naver" />} />
         <Route path="/oauth/redirect/google" element={<OauthRedirectPage type="google" />} />
-        <Route path="/restaurants/like" element={<WishListPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api/User/index.ts
+++ b/frontend/src/api/User/index.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import { setupInterceptorsTo } from '~/api/User/HttpUserInterceptor';
 
-import getToken from '~/utils/getToken';
-
 const axiosUserApi = (options?: Record<string, string>) => {
   const instance = axios.create({
     baseURL: `${process.env.BASE_URL}/api`,
@@ -17,14 +15,13 @@ const axiosUserApi = (options?: Record<string, string>) => {
 };
 
 const mswUserApi = (options?: Record<string, string>) => {
-  const token = getToken();
   const instance = axios.create({
     baseURL: '/',
     headers: {
       'Content-type': 'application/json',
-      Cookies: `JSESSIONID=${token}`,
       ...options,
     },
+    withCredentials: true,
   });
 
   return instance;

--- a/frontend/src/api/oauth.ts
+++ b/frontend/src/api/oauth.ts
@@ -46,3 +46,13 @@ export const postMSWRestaurantLike = async (restaurantId: number) => {
   const response = await userMSWInstance.post(`/restaurants/${restaurantId}/like`);
   return response.data;
 };
+
+export const deleteUserData = async (type: Oauth) => {
+  const response = await userInstance.delete(`/oauth/withdraw/${type}`);
+  return response.data;
+};
+
+export const deleteMSWUserData = async (type: Oauth) => {
+  const response = await userMSWInstance.delete(`/oauth/withdraw/${type}`);
+  return response.data;
+};

--- a/frontend/src/components/@common/Button/TextButton.tsx
+++ b/frontend/src/components/@common/Button/TextButton.tsx
@@ -7,6 +7,7 @@ interface TextButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   colorType: 'dark' | 'light';
   disabled?: boolean;
+  width?: `${string}px` | `${string}%`;
 }
 
 function TextButton({ text, colorType, disabled = false, ...props }: TextButtonProps) {
@@ -19,7 +20,9 @@ function TextButton({ text, colorType, disabled = false, ...props }: TextButtonP
 
 export default TextButton;
 
-const StyledButton = styled.button<{ colorType: 'dark' | 'light' }>`
+const StyledButton = styled.button<{ colorType: 'dark' | 'light'; width?: `${string}px` | `${string}%` }>`
+  width: ${({ width }) => width};
+
   padding: 1.2rem 2.4rem;
 
   border: none;

--- a/frontend/src/components/@common/Header/Header.tsx
+++ b/frontend/src/components/@common/Header/Header.tsx
@@ -25,9 +25,13 @@ function Header() {
   const handleInfoDropDown = (event: React.MouseEvent<HTMLElement>) => {
     const currentOption = event.currentTarget.dataset.name;
 
-    if (currentOption === '로그인') openModal();
+    if (currentOption === '로그인') {
+      openModal();
+    }
 
     if (currentOption === '위시리스트') navigator('/restaurants/like');
+
+    if (currentOption === '회원 탈퇴') navigator('/withdrawal');
 
     if (currentOption === '로그아웃') {
       if (oauth !== '') {

--- a/frontend/src/components/@common/Header/Header.tsx
+++ b/frontend/src/components/@common/Header/Header.tsx
@@ -25,9 +25,7 @@ function Header() {
   const handleInfoDropDown = (event: React.MouseEvent<HTMLElement>) => {
     const currentOption = event.currentTarget.dataset.name;
 
-    if (currentOption === '로그인') {
-      openModal();
-    }
+    if (currentOption === '로그인') openModal();
 
     if (currentOption === '위시리스트') navigator('/restaurants/like');
 

--- a/frontend/src/components/LoginPageUI/LoginPageUI.stories.tsx
+++ b/frontend/src/components/LoginPageUI/LoginPageUI.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LoginPageUI from '~/components/LoginPageUI';
+
+const meta: Meta<typeof LoginPageUI> = {
+  title: 'LoginPageUI',
+  component: LoginPageUI,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoginPageUI>;
+
+export const Default: Story = {
+  args: {
+    children: <div>hi</div>,
+  },
+};

--- a/frontend/src/components/LoginPageUI/LoginPageUI.tsx
+++ b/frontend/src/components/LoginPageUI/LoginPageUI.tsx
@@ -1,0 +1,77 @@
+import styled, { css } from 'styled-components';
+
+import Footer from '~/components/@common/Footer';
+import Header from '~/components/@common/Header';
+
+import useMediaQuery from '~/hooks/useMediaQuery';
+
+import { FONT_SIZE } from '~/styles/common';
+
+interface LoginPageUIProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function LoginPageUI({ title, children }: LoginPageUIProps) {
+  const { isMobile } = useMediaQuery();
+
+  return (
+    <StyledMobileLayout>
+      {!isMobile && <Header />}
+      <StyledContent isMobile={isMobile}>
+        <StyledTitle>{title}</StyledTitle>
+        {children}
+      </StyledContent>
+      <Footer />
+    </StyledMobileLayout>
+  );
+}
+
+export default LoginPageUI;
+
+const StyledMobileLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  min-height: 100dvh;
+`;
+
+const StyledTitle = styled.h2`
+  padding-bottom: 2rem;
+
+  font-size: ${FONT_SIZE.md};
+  border-bottom: 1px solid var(--gray-3);
+
+  text-align: center;
+
+  margin-bottom: 2rem;
+`;
+
+const StyledContent = styled.div<{ isMobile: boolean }>`
+  display: flex;
+  flex-direction: column;
+
+  position: relative;
+  z-index: 10;
+
+  min-height: 100px;
+
+  padding: 2rem;
+
+  border: 1px solid var(--gray-3);
+  border-radius: 12px;
+  background: var(--white);
+
+  ${({ isMobile }) =>
+    isMobile
+      ? css`
+          width: 100%;
+        `
+      : css`
+          width: 33%;
+          min-width: 500px;
+        `}
+`;

--- a/frontend/src/components/LoginPageUI/index.tsx
+++ b/frontend/src/components/LoginPageUI/index.tsx
@@ -1,0 +1,3 @@
+import LoginPageUI from '~/components/LoginPageUI/LoginPageUI';
+
+export default LoginPageUI;

--- a/frontend/src/components/RestaurantWishItem/RestaurantWishItem.tsx
+++ b/frontend/src/components/RestaurantWishItem/RestaurantWishItem.tsx
@@ -36,7 +36,7 @@ function RestaurantWishItem({ restaurant, celebs }: RestaurantWishItemProps) {
         <StyledImageViewer>
           <ImageCarousel images={images} type="list" />
           <LikeButton aria-label="좋아요" type="button" onClick={toggle}>
-            <Love fill={isLiked ? 'red' : '#000'} fillOpacity={0.8} aria-hidden="true" />
+            <Love width={20} fill={isLiked ? 'red' : '#000'} fillOpacity={0.8} aria-hidden="true" />
           </LikeButton>
         </StyledImageViewer>
         <section>

--- a/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.stories.tsx
+++ b/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WithdrawalModalContent from '~/components/WithdrawalModalContent/';
+
+const meta: Meta<typeof WithdrawalModalContent> = {
+  title: 'WithdrawalModalContent',
+  component: WithdrawalModalContent,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WithdrawalModalContent>;
+
+export const Default: Story = {};

--- a/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
+++ b/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
@@ -1,0 +1,75 @@
+import styled, { css } from 'styled-components';
+import TextButton from '~/components/@common/Button';
+import useMediaQuery from '~/hooks/useMediaQuery';
+import { FONT_SIZE } from '~/styles/common';
+
+function WithdrawalModalContent() {
+  const { isMobile } = useMediaQuery();
+
+  const onClick = () => {};
+
+  return (
+    <StyledWithdrawalModalContentWrapper>
+      <h4>주의하세요</h4>
+
+      <StyleWithdrawalContent>
+        <StyledWithdrawalText>탈퇴시 삭제/유지되는 정보를 확인하세요!</StyledWithdrawalText>
+        <StyledWithdrawalText>한 번 삭제되는 정보는 복구가 불가능합니다.</StyledWithdrawalText>
+      </StyleWithdrawalContent>
+
+      <StyleWithdrawalDetailWrapper>
+        <StyledWithdrawalDetailText>내가 좋아요한 음식점 데이터</StyledWithdrawalDetailText>
+        <StyledWithdrawalDetailText>위시리스트</StyledWithdrawalDetailText>
+        <StyledWithdrawalDetailText>음식점 댓글</StyledWithdrawalDetailText>
+      </StyleWithdrawalDetailWrapper>
+
+      <StyledButtonWrapper isMobile={isMobile}>
+        <TextButton type="button" text="취소하기" colorType="light" width="100%" onClick={onClick} />
+        <TextButton type="button" text="탈퇴하기" colorType="dark" width="100%" onClick={onClick} />
+      </StyledButtonWrapper>
+    </StyledWithdrawalModalContentWrapper>
+  );
+}
+
+export default WithdrawalModalContent;
+
+const StyledButtonWrapper = styled.div<{ isMobile: boolean }>`
+  display: flex;
+  gap: 3rem;
+
+  margin-top: 2rem;
+
+  ${({ isMobile }) =>
+    isMobile &&
+    css`
+      flex-direction: column;
+    `}
+`;
+
+const StyledWithdrawalText = styled.span`
+  color: gray;
+  font-size: ${FONT_SIZE.md};
+  line-height: 20px;
+`;
+
+const StyleWithdrawalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyleWithdrawalDetailWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledWithdrawalDetailText = styled.li`
+  color: var(--gray-4);
+  font-size: ${FONT_SIZE.md};
+  line-height: 24px;
+`;
+
+const StyledWithdrawalModalContentWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;

--- a/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
+++ b/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
@@ -1,12 +1,13 @@
 import styled, { css } from 'styled-components';
+
 import TextButton from '~/components/@common/Button';
+import useDeleteUser from '~/hooks/server/useDeleteUser';
 import useMediaQuery from '~/hooks/useMediaQuery';
 import { FONT_SIZE } from '~/styles/common';
 
 function WithdrawalModalContent() {
   const { isMobile } = useMediaQuery();
-
-  const onClick = () => {};
+  const { onCancelDeleteUser, deleteUser } = useDeleteUser();
 
   return (
     <StyledWithdrawalModalContentWrapper>
@@ -24,8 +25,8 @@ function WithdrawalModalContent() {
       </StyleWithdrawalDetailWrapper>
 
       <StyledButtonWrapper isMobile={isMobile}>
-        <TextButton type="button" text="취소하기" colorType="light" width="100%" onClick={onClick} />
-        <TextButton type="button" text="탈퇴하기" colorType="dark" width="100%" onClick={onClick} />
+        <TextButton type="button" text="취소하기" colorType="light" width="100%" onClick={onCancelDeleteUser} />
+        <TextButton type="button" text="탈퇴하기" colorType="dark" width="100%" onClick={deleteUser} />
       </StyledButtonWrapper>
     </StyledWithdrawalModalContentWrapper>
   );

--- a/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
+++ b/frontend/src/components/WithdrawalModalContent/WithdrawalModalContent.tsx
@@ -25,8 +25,8 @@ function WithdrawalModalContent() {
       </StyleWithdrawalDetailWrapper>
 
       <StyledButtonWrapper isMobile={isMobile}>
-        <TextButton type="button" text="취소하기" colorType="light" width="100%" onClick={onCancelDeleteUser} />
-        <TextButton type="button" text="탈퇴하기" colorType="dark" width="100%" onClick={deleteUser} />
+        <TextButton type="button" text="취소하기" colorType="dark" width="100%" onClick={onCancelDeleteUser} />
+        <TextButton type="button" text="탈퇴하기" colorType="light" width="100%" onClick={deleteUser} />
       </StyledButtonWrapper>
     </StyledWithdrawalModalContentWrapper>
   );

--- a/frontend/src/components/WithdrawalModalContent/index.tsx
+++ b/frontend/src/components/WithdrawalModalContent/index.tsx
@@ -1,0 +1,3 @@
+import WithdrawalModalContent from '~/components/WithdrawalModalContent/WithdrawalModalContent';
+
+export default WithdrawalModalContent;

--- a/frontend/src/constants/options.ts
+++ b/frontend/src/constants/options.ts
@@ -3,6 +3,7 @@ import All from '~/assets/all.png';
 export const OPTION_FOR_USER = [
   { id: 1, value: '로그아웃' },
   { id: 2, value: '위시리스트' },
+  { id: 3, value: '회원 탈퇴' },
 ];
 
 export const OPTION_FOR_NOT_USER = [{ id: 1, value: '로그인' }];

--- a/frontend/src/hooks/server/useDeleteUser.tsx
+++ b/frontend/src/hooks/server/useDeleteUser.tsx
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { shallow } from 'zustand/shallow';
+
+import useToastState from '~/hooks/store/useToastState';
+import useTokenState from '~/hooks/store/useTokenState';
+
+import { deleteUserData } from '~/api/oauth';
+
+const useDeleteUser = () => {
+  const navigator = useNavigate();
+  const oauth = useTokenState(state => state.oauth);
+  const { onFailure, close } = useToastState(
+    state => ({
+      onSuccess: state.onSuccess,
+      onFailure: state.onFailure,
+      close: state.close,
+    }),
+    shallow,
+  );
+
+  const onWithdraw = useMutation({
+    mutationFn: deleteUserData,
+
+    onSuccess: () => {
+      navigator('/');
+    },
+
+    onError: (error: AxiosError) => {
+      switch (error.response.status) {
+        case 401:
+          onFailure('로그인 후 다시 시도해주세요.');
+          break;
+        default:
+          onFailure(error.response.data as string);
+      }
+    },
+  });
+
+  const deleteUser = useCallback(() => {
+    if (oauth !== '') {
+      onWithdraw.mutate(oauth);
+    }
+
+    close();
+  }, []);
+
+  const onCancelDeleteUser = useCallback(() => {
+    navigator('/');
+  }, []);
+
+  return { onCancelDeleteUser, deleteUser };
+};
+
+export default useDeleteUser;

--- a/frontend/src/hooks/server/useToggleLikeNotUpdate.ts
+++ b/frontend/src/hooks/server/useToggleLikeNotUpdate.ts
@@ -9,7 +9,7 @@ import { postRestaurantLike } from '~/api/oauth';
 
 const useToggleLikeNotUpdate = (restaurant: Restaurant) => {
   const { value: isModalOpen, setTrue: openModal, setFalse: closeModal } = useBooleanState(false);
-  const { value: isLiked, toggle: toggleIsLiked } = useBooleanState(restaurant.isLiked);
+  const { value: isLiked, toggle: toggleIsLiked } = useBooleanState(true);
   const { onSuccess, onFailure, close } = useToastState(
     state => ({
       onSuccess: state.onSuccess,

--- a/frontend/src/hooks/server/useToggleLikeNotUpdate.ts
+++ b/frontend/src/hooks/server/useToggleLikeNotUpdate.ts
@@ -9,7 +9,7 @@ import { postRestaurantLike } from '~/api/oauth';
 
 const useToggleLikeNotUpdate = (restaurant: Restaurant) => {
   const { value: isModalOpen, setTrue: openModal, setFalse: closeModal } = useBooleanState(false);
-  const { value: isLiked, toggle: toggleIsLiked } = useBooleanState(true);
+  const { value: isLiked, toggle: toggleIsLiked } = useBooleanState(restaurant.isLiked ?? true);
   const { onSuccess, onFailure, close } = useToastState(
     state => ({
       onSuccess: state.onSuccess,

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -4,6 +4,7 @@ import {
   errorPostLike403Handlers,
   errorPostLike404Handlers,
   errorPostLike500Handlers,
+  error401handlers,
   handlers,
 } from './handlers';
 

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -1,4 +1,10 @@
-import type { ProfileData, RestaurantListData, RestaurantReview } from '~/@types/api.types';
+import type {
+  ProfileData,
+  RestaurantData,
+  RestaurantListData,
+  RestaurantReview,
+  RestaurantWishData,
+} from '~/@types/api.types';
 
 export let restaurantListData: RestaurantListData = {
   content: [
@@ -156,6 +162,151 @@ export let restaurantListData: RestaurantListData = {
   totalElementsCount: 5,
   currentElementsCount: 5,
 };
+
+export const restaurantWishListData: RestaurantWishData[] = [
+  {
+    lat: 37.5036335,
+    lng: 127.052218,
+    id: 330,
+    name: '배가무닭볶음탕',
+    category: '닭볶음탕',
+    roadAddress: '서울 강남구 선릉로86길 30 1층 배가무닭볶음탕',
+    phoneNumber: '0507-1476-9799',
+    naverMapUrl: 'https://naver.me/xB4hssJg',
+    distance: 269,
+    celebs: [
+      {
+        id: 6,
+        name: '야식이',
+        youtubeChannelName: '@yasigi',
+        profileImageUrl:
+          'https://yt3.googleusercontent.com/ytc/AOPolaQRjK6t7fPPaQrOdApWYUmbltGkWiN6ZowfUQFCMg=s176-c-k-c0x00ffffff-no-rj',
+      },
+    ],
+    images: [
+      {
+        id: 401,
+        name: 'eWFzaWdpX-uwsOqwgOustOuLreuztuydjO2DlQ.jpeg',
+        author: '@yasigi',
+        sns: '@yasigi',
+      },
+    ],
+  },
+  {
+    lat: 37.5036994,
+    lng: 127.0524166,
+    id: 116,
+    name: '60년전통신촌황소곱창 선릉직영점',
+    category: '곱창,막창,양',
+    roadAddress: '서울 강남구 선릉로86길 32',
+    phoneNumber: '02-553-6698',
+    naverMapUrl: 'https://naver.me/5HSEqwkA',
+    distance: 272,
+    celebs: [
+      {
+        id: 1,
+        name: '먹적 - (스시에 대출 박는 놈)',
+        youtubeChannelName: '@monstergourmet',
+        profileImageUrl:
+          'https://yt3.googleusercontent.com/ytc/AOPolaQ0vUJt9JWhig6GY1lWLPt_qIRiH-cKgO5Nnl5uicQ=s176-c-k-c0x00ffffff-no-rj',
+      },
+    ],
+    images: [
+      {
+        id: 47,
+        name: 'bW9uc3RlcmdvdXJtZXRfNjDrhYTsoITthrXsi6DstIztmanshozqs7HssL1f7ISg66aJ7KeB7JiB7KCQ.jpeg',
+        author: '@monstergourmet',
+        sns: '@monstergourmet',
+      },
+    ],
+  },
+  {
+    lat: 37.5047177,
+    lng: 127.0546534,
+    id: 68,
+    name: '숙성회장',
+    category: '일식당',
+    roadAddress: '서울 강남구 삼성로85길 32 동보빌딩 2층',
+    phoneNumber: '0507-1305-0805',
+    naverMapUrl:
+      'https://map.naver.com/v5/search/%EC%88%99%EC%84%B1%ED%9A%8C%EC%9E%A5/place/1459540460?entry=plt&c=15,0,0,0,dh&isCorrectAnswer=true',
+    distance: 364,
+    celebs: [
+      {
+        id: 3,
+        name: '맛객리우A foodie',
+        youtubeChannelName: '@Liwoo_foodie',
+        profileImageUrl:
+          'https://yt3.googleusercontent.com/KhKylYQTqpR3QQ1RuiYZ5xiM2fNsOJ_0jLFYbBBhk9Gh-zjpGTMUUSyPVGOHq4VZHzl6DN6qXQ=s176-c-k-c0x00ffffff-no-rj',
+      },
+    ],
+    images: [
+      {
+        id: 150,
+        name: 'bGl3b29f7IiZ7ISx7ZqM7J6l.jpeg',
+        author: '@Liwoo_foodie',
+        sns: '@Liwoo_foodie',
+      },
+    ],
+  },
+  {
+    lat: 37.5034458,
+    lng: 127.0538707,
+    id: 117,
+    name: '단초식당',
+    category: '육류,고기요리',
+    roadAddress: '서울 강남구 역삼로69길 27 1층 (우)06197',
+    phoneNumber: '02-555-6450',
+    naverMapUrl: 'https://place.map.kakao.com/1580574843',
+    distance: 377,
+    celebs: [
+      {
+        id: 1,
+        name: '먹적 - (스시에 대출 박는 놈)',
+        youtubeChannelName: '@monstergourmet',
+        profileImageUrl:
+          'https://yt3.googleusercontent.com/ytc/AOPolaQ0vUJt9JWhig6GY1lWLPt_qIRiH-cKgO5Nnl5uicQ=s176-c-k-c0x00ffffff-no-rj',
+      },
+    ],
+    images: [
+      {
+        id: 48,
+        name: 'bW9uc3RlcmdvdXJtZXRf64uo7LSI7Iud64u5.jpeg',
+        author: '@monstergourmet',
+        sns: '@monstergourmet',
+      },
+    ],
+  },
+  {
+    lat: 37.505202,
+    lng: 127.0553917,
+    id: 61,
+    name: '스시아오마츠',
+    category: '일식당',
+    roadAddress: '서울 강남구 테헤란로78길 16 지하1층 12호',
+    phoneNumber: '0507-1421-4224',
+    naverMapUrl:
+      'https://map.naver.com/v5/search/%EC%8A%A4%EC%8B%9C%EC%95%84%EC%98%A4%EB%A7%88%EC%B8%A0/place/1051920261?entry=plt&c=15,0,0,0,dh&isCorrectAnswer=true',
+    distance: 415,
+    celebs: [
+      {
+        id: 3,
+        name: '맛객리우A foodie',
+        youtubeChannelName: '@Liwoo_foodie',
+        profileImageUrl:
+          'https://yt3.googleusercontent.com/KhKylYQTqpR3QQ1RuiYZ5xiM2fNsOJ_0jLFYbBBhk9Gh-zjpGTMUUSyPVGOHq4VZHzl6DN6qXQ=s176-c-k-c0x00ffffff-no-rj',
+      },
+    ],
+    images: [
+      {
+        id: 143,
+        name: 'bGl3b29f7Iqk7Iuc7JWE7Jik66eI7Lig.jpeg',
+        author: '@Liwoo_foodie',
+        sns: '@Liwoo_foodie',
+      },
+    ],
+  },
+];
 
 export const profileData: ProfileData = {
   nickname: '푸만능',

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -19,6 +19,10 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(Fixture.restaurantReviews));
   }),
 
+  rest.delete('/oauth/withdraw/:oauthType', (req, res, ctx) => {
+    return res(ctx.status(204));
+  }),
+
   rest.post('/restaurants/:restaurantId/like', (req, res, ctx) => {
     const { restaurantId } = req.params;
 
@@ -49,6 +53,12 @@ export const errorPostLike400handlers = [
 
   rest.post('/restaurants/:restaurantId/like', (req, res, ctx) => {
     return res(ctx.status(400));
+  }),
+];
+
+export const error401handlers = [
+  rest.delete('/oauth/withdraw/:oauthType', (req, res, ctx) => {
+    return res(ctx.status(401));
   }),
 ];
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -12,11 +12,7 @@ export const handlers = [
   }),
 
   rest.get('/restaurants/like', (req, res, ctx) => {
-    const data = Fixture.restaurantListData.content.filter(restaurantItem => {
-      return restaurantItem.isLiked;
-    });
-
-    return res(ctx.status(200), ctx.json(data));
+    return res(ctx.status(200), ctx.json(Fixture.restaurantWishListData));
   }),
 
   rest.get('/restaurants/:restaurantId/reviews', (req, res, ctx) => {

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -1,61 +1,12 @@
-import styled from 'styled-components';
-
-import Footer from '~/components/@common/Footer';
-import Header from '~/components/@common/Header';
 import LoginModalContent from '~/components/LoginModalContent';
-import { FONT_SIZE } from '~/styles/common';
+import LoginPageUI from '~/components/LoginPageUI';
 
 function SignUpPage() {
   return (
-    <StyledMobileLayout>
-      <Header />
-      <StyledContent>
-        <StyledTitle>로그인 및 회원가입</StyledTitle>
-        <LoginModalContent />
-      </StyledContent>
-      <Footer />
-    </StyledMobileLayout>
+    <LoginPageUI title="로그인 및 회원가입">
+      <LoginModalContent />
+    </LoginPageUI>
   );
 }
 
 export default SignUpPage;
-
-const StyledMobileLayout = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-
-  width: 100%;
-  min-height: 100dvh;
-`;
-
-const StyledTitle = styled.h2`
-  padding-bottom: 2rem;
-
-  font-size: ${FONT_SIZE.md};
-  border-bottom: 1px solid var(--gray-3);
-
-  text-align: center;
-
-  margin-bottom: 2rem;
-`;
-
-const StyledContent = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  position: relative;
-  z-index: 10;
-
-  width: 33%;
-  min-width: 500px;
-  max-width: 600px;
-  min-height: 100px;
-
-  padding: 2rem;
-
-  border: 1px solid var(--gray-3);
-  border-radius: 12px;
-  background: var(--white);
-`;

--- a/frontend/src/pages/WithdrawalPage.tsx
+++ b/frontend/src/pages/WithdrawalPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import LoginPageUI from '~/components/LoginPageUI';
+import PopUpContainer from '~/components/PopUpContainer';
 import WithdrawalModalContent from '~/components/WithdrawalModalContent';
 import useTokenState from '~/hooks/store/useTokenState';
 
@@ -18,9 +19,12 @@ function WithdrawalPage() {
   }, []);
 
   return (
-    <LoginPageUI title="회원 탈퇴하기">
-      <WithdrawalModalContent />
-    </LoginPageUI>
+    <>
+      <LoginPageUI title="회원 탈퇴하기">
+        <WithdrawalModalContent />
+      </LoginPageUI>
+      <PopUpContainer />
+    </>
   );
 }
 

--- a/frontend/src/pages/WithdrawalPage.tsx
+++ b/frontend/src/pages/WithdrawalPage.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import LoginPageUI from '~/components/LoginPageUI';
+import WithdrawalModalContent from '~/components/WithdrawalModalContent';
+import useTokenState from '~/hooks/store/useTokenState';
+
+import { isEmptyString } from '~/utils/compare';
+
+function WithdrawalPage() {
+  const navigator = useNavigate();
+  const token = useTokenState(state => state.token);
+
+  useEffect(() => {
+    if (isEmptyString(token)) {
+      navigator('/signUp');
+    }
+  }, []);
+
+  return (
+    <LoginPageUI title="회원 탈퇴하기">
+      <WithdrawalModalContent />
+    </LoginPageUI>
+  );
+}
+
+export default WithdrawalPage;


### PR DESCRIPTION
## ✨ 요약
- [x] 위시리스트 명세에 맞게 기능 수정 -> 위시리스트의 좋아요를 프론트에서 관리 (데이터를 따로 받지 않음)
- [x] 회원 탈퇴 기능 구현 -> 탈퇴 페이지를 만들어서 구현 
- [x] 탈퇴 페이지 + 로그인 페이지 반응형 구현

## 기능 구현
![스크린샷 2023-08-15 오전 11 38 21](https://github.com/woowacourse-teams/2023-celuveat/assets/78203399/a084c974-3d55-42b0-8490-58ec6378d24b)

![스크린샷 2023-08-15 오전 11 41 13](https://github.com/woowacourse-teams/2023-celuveat/assets/78203399/7807b36a-9011-4454-8a6e-a01fdcee4029)

![스크린샷 2023-08-15 오전 11 42 11](https://github.com/woowacourse-teams/2023-celuveat/assets/78203399/03b9b252-8bf2-42a6-bf96-cdae1a7a055b)



## 😎 해결한 이슈
- close #342 #341 #343 

<br><br>
