### PR TITLE
feat: 회원 탈퇴 시 해당 회원의 데이터를 모두 지우는 로직 추가

### DIFF
--- a/backend/src/main/java/com/celuveat/auth/application/OauthService.java
+++ b/backend/src/main/java/com/celuveat/auth/application/OauthService.java
@@ -5,14 +5,17 @@ import com.celuveat.auth.domain.OauthMemberRepository;
 import com.celuveat.auth.domain.OauthServerType;
 import com.celuveat.auth.domain.authcode.AuthCodeRequestUrlProviderComposite;
 import com.celuveat.auth.domain.client.OauthMemberClientComposite;
+import com.celuveat.restaurant.domain.RestaurantLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class OauthService {
 
     private final OauthMemberRepository oauthMemberRepository;
+    private final RestaurantLikeRepository restaurantLikeRepository;
     private final OauthMemberClientComposite oauthMemberClientComposite;
     private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
 
@@ -20,6 +23,7 @@ public class OauthService {
         return authCodeRequestUrlProviderComposite.provide(oauthServerType);
     }
 
+    @Transactional
     public Long login(OauthServerType oauthServerType, String authCode) {
         OauthMember oauthMember = oauthMemberClientComposite.fetch(oauthServerType, authCode);
         OauthMember saved = oauthMemberRepository.findByOauthId(oauthMember.oauthId())
@@ -32,8 +36,11 @@ public class OauthService {
         oauthMemberClientComposite.logout(oauthServerType, oauthMember.oauthId());
     }
 
+    @Transactional
     public void withdraw(OauthServerType oauthServerType, Long oauthMemberId) {
         OauthMember oauthMember = oauthMemberRepository.getById(oauthMemberId);
-        oauthMemberClientComposite.withDraw(oauthServerType, oauthMember.oauthId());
+        oauthMemberClientComposite.withdraw(oauthServerType, oauthMember.oauthId());
+        restaurantLikeRepository.deleteAllByMemberId(oauthMemberId);
+        oauthMemberRepository.deleteById(oauthMemberId);
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClient.java
@@ -11,5 +11,5 @@ public interface OauthMemberClient {
 
     void logout(String oauthServerMemberId);
 
-    void withDraw(String oauthServerMemberId);
+    void withdraw(String oauthServerMemberId);
 }

--- a/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
+++ b/backend/src/main/java/com/celuveat/auth/domain/client/OauthMemberClientComposite.java
@@ -31,8 +31,8 @@ public class OauthMemberClientComposite {
         getClient(oauthServerType).logout(oauthId.oauthServerMemberId());
     }
 
-    public void withDraw(OauthServerType oauthServerType, OauthId oauthId) {
-        getClient(oauthServerType).withDraw(oauthId.oauthServerMemberId());
+    public void withdraw(OauthServerType oauthServerType, OauthId oauthId) {
+        getClient(oauthServerType).withdraw(oauthId.oauthServerMemberId());
     }
 
     private OauthMemberClient getClient(OauthServerType oauthServerType) {

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/google/client/GoogleMemberClient.java
@@ -46,6 +46,6 @@ public class GoogleMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void withDraw(String oauthServerMemberId) {
+    public void withdraw(String oauthServerMemberId) {
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoApiClient.java
@@ -27,7 +27,7 @@ public interface KakaoApiClient {
     );
 
     @PostExchange(url = "https://kapi.kakao.com/v1/user/unlink")
-    void withDrawMember(
+    void withdrawMember(
             @RequestHeader(name = AUTHORIZATION) String adminKey,
             @RequestBody MultiValueMap<String, String> params
     );

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/kakao/client/KakaoMemberClient.java
@@ -50,10 +50,10 @@ public class KakaoMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void withDraw(String oauthServerMemberId) {
+    public void withdraw(String oauthServerMemberId) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("target_id_type", "user_id");
         params.add("target_id", oauthServerMemberId);
-        kakaoApiClient.withDrawMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
+        kakaoApiClient.withdrawMember("KakaoAK " + kakaoOauthConfig.adminKey(), params);
     }
 }

--- a/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
+++ b/backend/src/main/java/com/celuveat/auth/infra/oauth/naver/client/NaverMemberClient.java
@@ -45,6 +45,6 @@ public class NaverMemberClient implements OauthMemberClient {
     }
 
     @Override
-    public void withDraw(String oauthServerMemberId) {
+    public void withdraw(String oauthServerMemberId) {
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantLikeRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/RestaurantLikeRepository.java
@@ -28,4 +28,6 @@ public interface RestaurantLikeRepository extends JpaRepository<RestaurantLike, 
             GROUP BY rl.restaurant.id
             """)
     List<RestaurantIdWithLikeCount> likeCountGroupByRestaurantsId(@Param("restaurantIds") List<Long> restaurantIds);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/backend/src/test/java/com/celuveat/acceptance/auth/MemberAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/auth/MemberAcceptanceSteps.java
@@ -24,4 +24,10 @@ public class MemberAcceptanceSteps {
         MemberProfileResponse responseBody = 응답.as(MemberProfileResponse.class);
         assertThat(responseBody).isEqualTo(예상_응답);
     }
+
+    public static ExtractableResponse<Response> 회원_탈퇴를_한다(String 세션_아이디, String oauthServerType) {
+        return given(세션_아이디)
+                .when().delete("/api/oauth/withdraw/{oauthServerType}", oauthServerType)
+                .then().extract();
+    }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/auth/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/auth/MemberAcceptanceTest.java
@@ -2,7 +2,9 @@ package com.celuveat.acceptance.auth;
 
 import static com.celuveat.acceptance.auth.MemberAcceptanceSteps.예상_응답;
 import static com.celuveat.acceptance.auth.MemberAcceptanceSteps.응답을_검증한다;
+import static com.celuveat.acceptance.auth.MemberAcceptanceSteps.회원_탈퇴를_한다;
 import static com.celuveat.acceptance.auth.MemberAcceptanceSteps.회원정보_조회를_요청한다;
+import static com.celuveat.acceptance.common.AcceptanceSteps.내용_없음;
 import static com.celuveat.acceptance.common.AcceptanceSteps.응답_상태를_검증한다;
 import static com.celuveat.acceptance.common.AcceptanceSteps.정상_처리;
 import static com.celuveat.auth.fixture.OauthMemberFixture.멤버;
@@ -27,5 +29,18 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         // then
         응답_상태를_검증한다(응답, 정상_처리);
         응답을_검증한다(응답, 예상_응답);
+    }
+
+    @Test
+    void 회원을_탈퇴한다() {
+        // given
+        var 도기 = 멤버("도기");
+        var 세션_아이디 = 회원가입하고_로그인한다(도기);
+
+        // when
+        var 회원탈퇴_응답 = 회원_탈퇴를_한다(세션_아이디, "kakao");
+
+        // then
+        응답_상태를_검증한다(회원탈퇴_응답, 내용_없음);
     }
 }

--- a/backend/src/test/java/com/celuveat/auth/application/OauthServiceTest.java
+++ b/backend/src/test/java/com/celuveat/auth/application/OauthServiceTest.java
@@ -1,0 +1,78 @@
+package com.celuveat.auth.application;
+
+import static com.celuveat.auth.domain.OauthServerType.KAKAO;
+import static com.celuveat.auth.exception.AuthExceptionType.NOT_FOUND_MEMBER;
+import static com.celuveat.auth.fixture.OauthMemberFixture.멤버;
+import static com.celuveat.restaurant.fixture.RestaurantFixture.음식점;
+import static com.celuveat.restaurant.fixture.RestaurantLikeFixture.음식점_좋아요;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.celuveat.auth.domain.OauthMember;
+import com.celuveat.auth.domain.OauthMemberRepository;
+import com.celuveat.auth.domain.authcode.AuthCodeRequestUrlProviderComposite;
+import com.celuveat.auth.domain.client.OauthMemberClient;
+import com.celuveat.auth.domain.client.OauthMemberClientComposite;
+import com.celuveat.auth.exception.AuthException;
+import com.celuveat.auth.infra.kakao.FakeKakaoMemberClient;
+import com.celuveat.common.IntegrationTest;
+import com.celuveat.common.exception.BaseExceptionType;
+import com.celuveat.restaurant.domain.Restaurant;
+import com.celuveat.restaurant.domain.RestaurantLikeRepository;
+import com.celuveat.restaurant.domain.RestaurantRepository;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("Oauth 관련 서비스(OauthService) 은(는)")
+class OauthServiceTest {
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @Autowired
+    private OauthMemberRepository oauthMemberRepository;
+
+    @Autowired
+    private RestaurantLikeRepository restaurantLikeRepository;
+
+    @Autowired
+    private AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
+
+    private OauthService oauthService;
+    private final OauthMemberClient memberClient = new FakeKakaoMemberClient();
+    private final OauthMemberClientComposite clientComposite = new OauthMemberClientComposite(Set.of(memberClient));
+
+    @BeforeEach
+    void setUp() {
+        this.oauthService = new OauthService(
+                oauthMemberRepository,
+                restaurantLikeRepository,
+                clientComposite,
+                authCodeRequestUrlProviderComposite
+        );
+    }
+
+    @Test
+    void 회원_탈퇴하면_회원의_좋아요와_정보가_모두_삭제된다() {
+        // given
+        Restaurant 새벽집 = restaurantRepository.save(음식점("새벽집"));
+        OauthMember 도기 = oauthMemberRepository.save(멤버("도기"));
+        restaurantLikeRepository.save(음식점_좋아요(새벽집, 도기));
+
+        // when
+        oauthService.withdraw(KAKAO, 도기.id());
+
+        // then
+        assertThat(restaurantLikeRepository.countByRestaurant(새벽집)).isEqualTo(0);
+        BaseExceptionType exceptionType = assertThrows(AuthException.class,
+                () -> oauthMemberRepository.getById(도기.id())).exceptionType();
+        assertThat(exceptionType).isEqualTo(NOT_FOUND_MEMBER);
+    }
+}

--- a/backend/src/test/java/com/celuveat/auth/infra/kakao/FakeKakaoMemberClient.java
+++ b/backend/src/test/java/com/celuveat/auth/infra/kakao/FakeKakaoMemberClient.java
@@ -1,0 +1,28 @@
+package com.celuveat.auth.infra.kakao;
+
+import static com.celuveat.auth.domain.OauthServerType.KAKAO;
+
+import com.celuveat.auth.domain.OauthMember;
+import com.celuveat.auth.domain.OauthServerType;
+import com.celuveat.auth.domain.client.OauthMemberClient;
+
+public class FakeKakaoMemberClient implements OauthMemberClient {
+
+    @Override
+    public OauthServerType supportServer() {
+        return KAKAO;
+    }
+
+    @Override
+    public OauthMember fetch(String code) {
+        return null;
+    }
+
+    @Override
+    public void logout(String oauthServerMemberId) {
+    }
+
+    @Override
+    public void withdraw(String oauthServerMemberId) {
+    }
+}

--- a/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/domain/RestaurantQueryRepositoryTest.java
@@ -5,7 +5,6 @@ import static com.celuveat.restaurant.fixture.LocationFixture.박스_1_2번_지�
 import static com.celuveat.restaurant.fixture.LocationFixture.박스_1번_지점포함;
 import static com.celuveat.restaurant.fixture.LocationFixture.전체영역_검색_범위;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.isCelebVisited;
-import static com.celuveat.restaurant.fixture.RestaurantFixture.국민연금_구내식당;
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,7 +31,7 @@ import org.springframework.data.domain.PageRequest;
 
 @IntegrationTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@DisplayName("레스토랑 조회용 Repo(RestaurantQueryRepository) 은(는)")
+@DisplayName("음식점 조회용 레포지토리(RestaurantQueryRepository) 은(는)")
 class RestaurantQueryRepositoryTest {
 
     private final List<RestaurantSimpleResponse> seed = new ArrayList<>();
@@ -354,7 +353,7 @@ class RestaurantQueryRepositoryTest {
         // when
         Page<RestaurantWithDistance> result = restaurantQueryRepository.getRestaurantsNearByRestaurantId(
                 specificDistance,
-                국민연금_구내식당.id(),
+                1L,
                 PageRequest.of(0, 4)
         );
 


### PR DESCRIPTION
## ✨ 요약
1. 카카오 OAuth 회원 탈퇴 시, 해당 회원 관련 정보(좋아요 등)를 모두 지우는 로직 추가했습니다.

<br>

## 😎 해결한 이슈
- close #368 

<br>
