### PR TITLE
hotfix: 회원 요청 로깅 분리

### DIFF
--- a/backend/src/main/java/com/celuveat/common/log/context/AuthenticatedLogId.java
+++ b/backend/src/main/java/com/celuveat/common/log/context/AuthenticatedLogId.java
@@ -1,15 +1,19 @@
 package com.celuveat.common.log.context;
 
+import java.util.UUID;
+
 public class AuthenticatedLogId implements LogId {
 
     private final String memberId;
+    private final String requestId;
 
     public AuthenticatedLogId(Object memberId) {
         this.memberId = String.valueOf(memberId);
+        this.requestId = UUID.randomUUID().toString().substring(0, 8);
     }
 
     @Override
     public String logId() {
-        return memberId + "(memberId)";
+        return memberId + "(memberId)" + "-" + requestId;
     }
 }


### PR DESCRIPTION
## ✨ 요약
```
회원 요청에 대한 로깅을 구분할 수 있도록 요청 단위의 식별자를 부여했습니다.
```