### PR TITLE
feat: 데이터 저장 기능 고도화

### DIFF
--- a/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
+++ b/backend/src/main/java/com/celuveat/admin/exception/AdminExceptionType.java
@@ -10,11 +10,12 @@ import org.springframework.http.HttpStatus;
 public enum AdminExceptionType implements BaseExceptionType {
 
     NOT_EXISTS_CELEB(BAD_REQUEST, "셀럽이 저장되어 있지 않습니다. 셀럽 먼저 저장해주세요."),
-    ILLEGAL_DATE_FORMAT(BAD_REQUEST, "영상 업로드 날짜 형식이 잘못됐습니다. \'yyyy. MM. dd\' 형식으로 입력해주세요."),
+    ILLEGAL_DATE_FORMAT(BAD_REQUEST, "영상 업로드 날짜 형식이 잘못됐습니다. \'yyyy. M. d\' 형식으로 입력해주세요."),
     ILLEGAL_FORMAT(BAD_REQUEST, "데이터 저장 양식이 잘못됐습니다. 엑셀 폼을 준수해주세요."),
     EXIST_NULL(BAD_REQUEST, "입력되지 않은 값이 있습니다."),
     INVALID_YOUTUBE_CHANNEL_NAME(BAD_REQUEST, "유튜브 채널 명이 잘못됐습니다. 앞에 '@'를 붙여주세요."),
     INVALID_URL_PATTERN(BAD_REQUEST, "URL 패턴이 잘못됐습니다. 확인 후 다시 입력해주세요."),
+    MISMATCH_COUNT_YOUTUBE_VIDEO_LINK_AND_UPLOAD_DATE(BAD_REQUEST, "유튜브 영상 링크와 업로드 일에 입력된 값의 개수가 다릅니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
@@ -27,7 +27,7 @@ public class AdminController {
     ResponseEntity<Void> saveData(@RequestBody String rawData) {
         String[] rows = rawData.split(System.lineSeparator());
         List<SaveDataRequest> requests = Arrays.stream(rows)
-                .map(row -> row.split(TAB))
+                .map(row -> row.split(TAB, -1))
                 .map(SaveDataRequest::from)
                 .toList();
         adminService.saveData(requests);

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
@@ -71,7 +71,7 @@ public record SaveDataRequest(
             String imageName,
             Restaurant restaurant
     ) {
-        SocialMedia socialMedia = SocialMedia.getBasedOn(instagramName);
+        SocialMedia socialMedia = SocialMedia.from(instagramName);
         String author = switch (socialMedia) {
             case INSTAGRAM -> instagramName;
             default -> youtubeChannelName;

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
@@ -20,20 +20,22 @@ public record SaveDataRequest(
         String naverMapUrl,
         String videoUploadDate,
         String latitude,
-        String longitude
+        String longitude,
+        String instagramName
 ) {
 
-    private static final int YOUTUBE_CHANNEL_NAME = 0;
-    private static final int IMAGE_NAME = 1;
+    private static final int RESTAURANT_NAME = 0;
+    private static final int YOUTUBE_CHANNEL_NAME = 1;
     private static final int YOUTUBE_VIDEO_URL = 2;
     private static final int UPLOAD_DATE = 3;
-    private static final int RESTAURANT_NAME = 4;
-    private static final int ROAD_ADDRESS = 5;
-    private static final int PHONE_NUMBER = 6;
-    private static final int CATEGORY = 7;
-    private static final int NAVER_MAP_URL = 8;
-    private static final int LATITUDE = 9;
-    private static final int LONGITUDE = 10;
+    private static final int ROAD_ADDRESS = 4;
+    private static final int PHONE_NUMBER = 5;
+    private static final int CATEGORY = 6;
+    private static final int LATITUDE = 7;
+    private static final int LONGITUDE = 8;
+    private static final int NAVER_MAP_URL = 9;
+    private static final int IMAGE_NAME = 10;
+    private static final int INSTAGRAM_NAME = 11;
 
     public static SaveDataRequest from(String[] data) {
         return SaveDataRequest.builder()
@@ -48,6 +50,7 @@ public record SaveDataRequest(
                 .naverMapUrl(data[NAVER_MAP_URL])
                 .latitude(data[LATITUDE])
                 .longitude(data[LONGITUDE])
+                .instagramName(data[INSTAGRAM_NAME])
                 .build();
     }
 
@@ -64,19 +67,29 @@ public record SaveDataRequest(
                 .build();
     }
 
-    public RestaurantImage toRestaurantImage(String imageName, SocialMedia socialMedia, Restaurant restaurant) {
+    public RestaurantImage toRestaurantImage(
+            String imageName,
+            Restaurant restaurant
+    ) {
+        SocialMedia socialMedia = SocialMedia.getBasedOn(instagramName);
+        String author;
+        switch (socialMedia) {
+            case INSTAGRAM -> author = instagramName;
+            default -> author = youtubeChannelName;
+        }
+
         return RestaurantImage.builder()
                 .name(imageName)
-                .author(youtubeChannelName)
+                .author(author)
                 .socialMedia(socialMedia)
                 .restaurant(restaurant)
                 .build();
     }
 
-    public Video toVideo(Celeb celeb, Restaurant restaurant, LocalDate localDate) {
+    public Video toVideo(String youtubeVideoUrl, LocalDate uploadDate, Celeb celeb, Restaurant restaurant) {
         return Video.builder()
                 .youtubeUrl(youtubeVideoUrl)
-                .uploadDate(localDate)
+                .uploadDate(uploadDate)
                 .celeb(celeb)
                 .restaurant(restaurant)
                 .build();

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
@@ -72,11 +72,10 @@ public record SaveDataRequest(
             Restaurant restaurant
     ) {
         SocialMedia socialMedia = SocialMedia.getBasedOn(instagramName);
-        String author;
-        switch (socialMedia) {
-            case INSTAGRAM -> author = instagramName;
-            default -> author = youtubeChannelName;
-        }
+        String author = switch (socialMedia) {
+            case INSTAGRAM -> instagramName;
+            default -> youtubeChannelName;
+        };
 
         return RestaurantImage.builder()
                 .name(imageName)

--- a/backend/src/main/java/com/celuveat/restaurant/domain/SocialMedia.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/SocialMedia.java
@@ -5,4 +5,11 @@ public enum SocialMedia {
     YOUTUBE,
     INSTAGRAM,
     ;
+
+    public static SocialMedia getBasedOn(String instagramName) {
+        if (instagramName.strip().isBlank()) {
+            return YOUTUBE;
+        }
+        return INSTAGRAM;
+    }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/domain/SocialMedia.java
+++ b/backend/src/main/java/com/celuveat/restaurant/domain/SocialMedia.java
@@ -6,7 +6,7 @@ public enum SocialMedia {
     INSTAGRAM,
     ;
 
-    public static SocialMedia getBasedOn(String instagramName) {
+    public static SocialMedia from(String instagramName) {
         if (instagramName.strip().isBlank()) {
             return YOUTUBE;
         }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
@@ -14,25 +14,41 @@ import java.util.List;
 public class AdminAcceptanceSteps {
 
     public static final String TAB = "\t";
+    public static final String 줄바꿈 = System.lineSeparator();
+
+    public static String 데이터_입력_생성(
+            String 셀럽_이름,
+            String 음식점_이름,
+            String 유튜브_영상_링크,
+            String 영상_업로드_일,
+            String 인스타_아이디
+    ) {
+        return 음식점_이름 +
+                TAB + "@" + 셀럽_이름 +
+                TAB + 유튜브_영상_링크 +
+                TAB + 영상_업로드_일 +
+                TAB + 음식점_이름 + " 주소" +
+                TAB + "전화번호" +
+                TAB + "카테고리" +
+                TAB + "12.3456" +
+                TAB + "12.3456" +
+                TAB + "음식점네이버링크" +
+                TAB + 음식점_이름 + ".png" +
+                TAB + 인스타_아이디;
+    }
 
     public static String 데이터_입력_생성(String 셀럽_이름, String 음식점_이름) {
-        return "@" + 셀럽_이름 +
-                "\t" + 음식점_이름 + "png" +
-                "\t유튜브링크" +
-                "\t2023. 7. 25." +
-                "\t" + 음식점_이름 +
-                "\t" + 음식점_이름 + " 주소" +
-                "\t전화번호" +
-                "\t카테고리" +
-                "\t음식점네이버링크" +
-                "\t12.3456" +
-                "\t12.3456";
+        return 데이터_입력_생성(셀럽_이름, 음식점_이름, "유튜브영상링크", "2027. 7. 2.", "");
+    }
+
+    public static String 데이터_입력_생성(String 셀럽_이름, String 음식점_이름, String 인스타_아이디) {
+        return 데이터_입력_생성(셀럽_이름, 음식점_이름, "유튜브영상링크", "2027. 7. 2.", 인스타_아이디);
     }
 
     public static List<SaveDataRequest> 데이터_저장_요청_생성(String input) {
         String[] rows = input.split(System.lineSeparator());
         return Arrays.stream(rows)
-                .map(row -> row.split(TAB))
+                .map(row -> row.split(TAB, -1))
                 .map(SaveDataRequest::from)
                 .toList();
     }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
@@ -5,6 +5,7 @@ import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저�
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청_생성;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.줄바꿈;
 import static com.celuveat.admin.exception.AdminExceptionType.EXIST_NULL;
 import static com.celuveat.admin.exception.AdminExceptionType.INVALID_URL_PATTERN;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
@@ -22,8 +23,6 @@ import org.junit.jupiter.api.Test;
 @DisplayName("어드민 인수 테스트")
 class AdminAcceptanceTest extends AcceptanceTest {
 
-    private final String 줄바꿈 = System.lineSeparator();
-
     @Nested
     class 음식점_데이터_저장 {
 
@@ -35,9 +34,9 @@ class AdminAcceptanceTest extends AcceptanceTest {
             셀럽_저장(셀럽("말랑"));
             셀럽_저장(셀럽("오도"));
 
-            String 입력_데이터 = 데이터_입력_생성("도기", "국민연금, 국민연금2")
+            String 입력_데이터 = 데이터_입력_생성("도기", "국민연금")
                     + 줄바꿈
-                    + 데이터_입력_생성("도기", "농민백암순대, 농민백암순대2, 농민백암순대3")
+                    + 데이터_입력_생성("도기", "농민백암순대")
                     + 줄바꿈
                     + 데이터_입력_생성("로이스", "신천직화")
                     + 줄바꿈
@@ -52,8 +51,8 @@ class AdminAcceptanceTest extends AcceptanceTest {
 
             // then
             셀럽_수_검증(4);
-            음식점_수_검증(5);
-            음식점_이미지_수_검증(9);
+            음식점_수_검증(4);
+            음식점_이미지_수_검증(6);
             영상_수_검증(6);
         }
 

--- a/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/celuveat/admin/application/AdminServiceTest.java
@@ -1,12 +1,16 @@
 package com.celuveat.admin.application;
 
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.TAB;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저장_요청_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청_생성;
 import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_DATE_FORMAT;
+import static com.celuveat.admin.exception.AdminExceptionType.MISMATCH_COUNT_YOUTUBE_VIDEO_LINK_AND_UPLOAD_DATE;
 import static com.celuveat.admin.exception.AdminExceptionType.NOT_EXISTS_CELEB;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
+import static com.celuveat.restaurant.domain.SocialMedia.INSTAGRAM;
+import static com.celuveat.restaurant.domain.SocialMedia.YOUTUBE;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.국민연금_구내식당;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,6 +23,7 @@ import com.celuveat.celeb.domain.CelebRepository;
 import com.celuveat.common.IntegrationTest;
 import com.celuveat.common.exception.BaseExceptionType;
 import com.celuveat.restaurant.domain.Restaurant;
+import com.celuveat.restaurant.domain.RestaurantImage;
 import com.celuveat.restaurant.domain.RestaurantImageRepository;
 import com.celuveat.restaurant.domain.RestaurantRepository;
 import com.celuveat.video.domain.VideoRepository;
@@ -59,6 +64,7 @@ class AdminServiceTest {
         void 저장되어_있지_않은_셀럽으로_데이터를_저장하면_예외가_발생한다() {
             // given
             String input = 데이터_입력_생성("도기", "국민연금");
+
             List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
             // then
@@ -68,13 +74,13 @@ class AdminServiceTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"2023. 7. 23. ", "23. 7. 23.", "2023.7.23", "2023. 7.8."})
+        @ValueSource(strings = {"23. 7. 23.", "2023.7.23", "2023. 7.8."})
         void 날짜_형식이_다른_경우_예외가_발생한다(String 영상_업로드_날짜) {
             // given
             셀럽_저장(셀럽("도기"));
 
             // when
-            String input = 잘못된_입력_생성("도기", "농민백암순대", 영상_업로드_날짜);
+            String input = 영상_업로드_날짜가_잘못된_입력_생성("도기", "농민백암순대", 영상_업로드_날짜);
             List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
             // then
@@ -89,7 +95,9 @@ class AdminServiceTest {
             셀럽_저장(셀럽("도기"));
             음식점_저장(국민연금_구내식당);
 
-            String input = 데이터_입력_생성("도기", "국민연금") + System.lineSeparator() + 데이터_입력_생성("도기", "농민백암순대");
+            String input = 데이터_입력_생성("도기", "국민연금")
+                    + System.lineSeparator()
+                    + 데이터_입력_생성("도기", "농민백암순대");
             List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
             // when
@@ -109,7 +117,9 @@ class AdminServiceTest {
             셀럽_저장(셀럽("로이스"));
             음식점_저장(국민연금_구내식당);
 
-            String input = 데이터_입력_생성("도기", "국민연금") + System.lineSeparator() + 데이터_입력_생성("로이스", "국민연금");
+            String input = 데이터_입력_생성("도기", "국민연금")
+                    + System.lineSeparator()
+                    + 데이터_입력_생성("로이스", "국민연금");
             List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
 
             // when
@@ -138,6 +148,83 @@ class AdminServiceTest {
             assertThat(restaurantRepository.count()).isEqualTo(1);
             assertThat(restaurantImageRepository.count()).isEqualTo(1);
             assertThat(videoRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        void 인스타_아이디가_입력되지_않으면_socialMedia는_YOUTUBE로_저장된다() {
+            // given
+            셀럽_저장(셀럽("도기"));
+
+            String input = 데이터_입력_생성("도기", "국민연금");
+            List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
+
+            // when
+            adminService.saveData(요청);
+
+            // then
+            assertThat(restaurantImageRepository.getReferenceById(1L).socialMedia()).isEqualTo(YOUTUBE);
+        }
+
+        @Test
+        void 인스타_아이디가_입력되면_해당_정보가_저장된다() {
+            // given
+            String instagramName = "doggy";
+            셀럽_저장(셀럽("도기"));
+            String input = 데이터_입력_생성("도기", "국민연금", instagramName);
+            List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
+
+            // when
+            adminService.saveData(요청);
+
+            // then
+            RestaurantImage image = restaurantImageRepository.getReferenceById(1L);
+            assertThat(image.socialMedia()).isEqualTo(INSTAGRAM);
+            assertThat(image.author()).isEqualTo(instagramName);
+        }
+
+        @Test
+        void 둘_이상의_유튜브_영상_링크를_한번에_저장할_수_있다() {
+            // given
+            셀럽_저장(셀럽("도기"));
+
+            String input = 데이터_입력_생성(
+                    "도기",
+                    "국민연금",
+                    "영상링크1, 영상링크2",
+                    "1987. 6. 8., 1945. 4. 15.",
+                    "doggy"
+            );
+            List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
+
+            // when
+            adminService.saveData(요청);
+
+            // then
+            assertThat(celebRepository.count()).isEqualTo(1);
+            assertThat(restaurantRepository.count()).isEqualTo(1);
+            assertThat(restaurantImageRepository.count()).isEqualTo(1);
+            assertThat(videoRepository.count()).isEqualTo(2);
+        }
+
+        @Test
+        void 영상_링크와_업로드_일의_수가_다르면_예외가_발생한다() {
+            // given
+            셀럽_저장(셀럽("도기"));
+
+            String input = 데이터_입력_생성(
+                    "도기",
+                    "국민연금",
+                    "영상링크1, 영상링크2",
+                    "1987. 6. 8., 1945. 4. 15., 2023. 8. 31.",
+                    "doggy"
+            );
+            List<SaveDataRequest> 요청 = 데이터_저장_요청_생성(input);
+
+            // when
+            BaseExceptionType exceptionType = assertThrows(AdminException.class,
+                    () -> adminService.saveData(요청)
+            ).exceptionType();
+            assertThat(exceptionType).isEqualTo(MISMATCH_COUNT_YOUTUBE_VIDEO_LINK_AND_UPLOAD_DATE);
         }
     }
 
@@ -172,17 +259,18 @@ class AdminServiceTest {
         return restaurantRepository.save(음식점);
     }
 
-    private String 잘못된_입력_생성(String 셀럽_이름, String 음식점_이름, String 영상_업로드_날짜) {
-        return "@" + 셀럽_이름 +
-                "\t" + 음식점_이름 + "png" +
-                "\t유튜브링크" +
-                "\t" + 영상_업로드_날짜 +
-                "\t" + 음식점_이름 +
-                "\t" + 음식점_이름 + " 주소" +
-                "\t전화번호" +
-                "\t카테고리" +
-                "\t음식점네이버링크" +
-                "\t12.3456" +
-                "\t12.3456";
+    private String 영상_업로드_날짜가_잘못된_입력_생성(String 셀럽_이름, String 음식점_이름, String 영상_업로드_날짜) {
+        return 음식점_이름 +
+                TAB + "@" + 셀럽_이름 +
+                TAB + "유튜브 영상 링크" +
+                TAB + 영상_업로드_날짜 +
+                TAB + 음식점_이름 + " 주소" +
+                TAB + "전화번호" +
+                TAB + "카테고리" +
+                TAB + "12.3456" +
+                TAB + "12.3456" +
+                TAB + "음식점네이버링크" +
+                TAB + 음식점_이름 + ".png" +
+                TAB + "인스타 아이디";
     }
 }


### PR DESCRIPTION
## ✨ 요약
- 데이터 취합 폼 변경에 대응했습니다.
- 데이터 저장 기능을 고도화 했습니다.
  - 취합 폼에서 인스타 아이디를 Optional하게 입력받을 수 있도록 했습니다. 
    - 입력 X -> `RestaurantImage`의 `author` = `유튜브 채널 이름`, `socialMedia` = `YOUTUBE` 저장
    - 입력 O -> `RestaurantImage`의 `author` = `인스타 아이디`, `socialMedia` = `INSTAGRAM` 저장
  - 제레미의 요청에 따라 유튜브 영상도 한번에 2개 이상 입력받을 수 있도록 했습니다.
    - 이때, 유튜브 영상 링크와 업로드 날짜의 순서와 개수가 맞아야합니다.
    - 개수가 맞지 않으면 예외가 발생하도록 했습니다.

<br>

## 😎 해결한 이슈
- close #399 
