### PR TITLE
feat: 브라우저 꺼져도 쿠키 안사라지게 만들기

### DIFF
--- a/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
+++ b/backend/src/main/java/com/celuveat/auth/presentation/OauthController.java
@@ -5,6 +5,7 @@ import static com.celuveat.common.auth.AuthConstant.JSESSION_ID;
 import com.celuveat.auth.command.application.OauthService;
 import com.celuveat.auth.command.domain.OauthServerType;
 import com.celuveat.common.auth.Auth;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -52,10 +53,15 @@ public class OauthController {
     ResponseEntity<Void> logout(
             @PathVariable OauthServerType oauthServerType,
             @Auth Long memberId,
-            HttpServletRequest request
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
         oauthService.logout(oauthServerType, memberId);
         request.getSession(false).invalidate();
+        Cookie cookie = new Cookie(JSESSION_ID, "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
         return ResponseEntity.noContent().build();
     }
 


### PR DESCRIPTION
## ✨ 요약
```
서브 모듈에 쿠키 기본 max-age, path 설정 했습니다. 브라우저 꺼져도 만료되기 전까지 지워지지 않습니다.
로그아웃시 max-age: 0 으로 Set-Cookie 헤더 내려서 브라우저 쿠키 지우도록 했습니다.
Http-Only 설정은 false로 해야 프론트에서 쿠키를 확인할 수 있어서 추가했습니다.
```

<br><br>

## 😎 해결한 이슈
- close #427 

<br><br>
