### PR TITLE
fix: safari에서 infodropdown onblur이벤트가 먹히지 않는 에러

### DIFF
--- a/frontend/src/components/InfoDropDown/InfoDropDown.tsx
+++ b/frontend/src/components/InfoDropDown/InfoDropDown.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useRef } from 'react';
 import styled from 'styled-components';
 import { ProfileData } from '~/@types/api.types';
 import { getProfile } from '~/api/user';
@@ -7,6 +8,7 @@ import InfoButton from '~/components/@common/InfoButton';
 import InfoDropDownOption from '~/components/InfoDropDown/InfoDropDownOption';
 import { OPTION_FOR_NOT_USER, OPTION_FOR_USER } from '~/constants/options';
 import useBooleanState from '~/hooks/useBooleanState';
+import useOnClickOutside from '~/hooks/useOnClickOutside';
 
 interface DropDownProps {
   isOpen?: boolean;
@@ -15,7 +17,9 @@ interface DropDownProps {
 }
 
 function InfoDropDown({ externalOnClick, isOpen = false, label }: DropDownProps) {
-  const { value: isShow, toggle: onToggleDropDown, setFalse: onCloseDropDown } = useBooleanState(isOpen);
+  const { value: isShow, toggle: onToggleDropDown, setFalse: closeDropDown } = useBooleanState(isOpen);
+  const ref = useRef();
+  useOnClickOutside(ref, closeDropDown);
 
   const { data, isSuccess } = useQuery<ProfileData>({
     queryKey: ['profile'],
@@ -30,7 +34,7 @@ function InfoDropDown({ externalOnClick, isOpen = false, label }: DropDownProps)
 
   return (
     <StyledInfoDropDown aria-hidden>
-      <StyledInfoButtonWrapper onClick={onToggleDropDown} onBlur={onCloseDropDown} aria-label={label}>
+      <StyledInfoButtonWrapper ref={ref} onClick={onToggleDropDown} aria-label={label}>
         <InfoButton profile={data} isShow={isShow} isSuccess={isSuccess} />
       </StyledInfoButtonWrapper>
 


### PR DESCRIPTION
## ✨ 요약
- safari에서 infodropdown onblur이벤트가 먹히지 않는 에러

에러 상황
https://github.com/woowacourse-teams/2023-celuveat/assets/78203399/03c0d4b8-2684-49b4-b682-33433c25cbf6

해결
https://github.com/woowacourse-teams/2023-celuveat/assets/78203399/61a28307-22ce-41b0-9c2c-158f91226b90

