### PR TITLE
refactor: 리뷰 조회시 이미지, 평점, 좋아요 여부 포함하여 응답

### DIFF
--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewLikeService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewLikeService.java
@@ -19,8 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RestaurantReviewLikeService {
 
-    private final RestaurantReviewRepository restaurantReviewRepository;
     private final OauthMemberRepository oauthMemberRepository;
+    private final RestaurantReviewRepository restaurantReviewRepository;
     private final RestaurantReviewLikeRepository restaurantReviewLikeRepository;
 
     public void like(Long restaurantReviewId, Long memberId) {
@@ -30,14 +30,16 @@ public class RestaurantReviewLikeService {
             throw new RestaurantReviewException(CAN_NOT_LIKE_MY_REVIEW);
         }
         restaurantReviewLikeRepository.findByRestaurantReviewAndMember(restaurantReview, member)
-                .ifPresentOrElse(cancelLike(), clickLike(restaurantReview, member));
+                .ifPresentOrElse(cancelLike(restaurantReview), clickLike(restaurantReview, member));
     }
 
-    private Consumer<RestaurantReviewLike> cancelLike() {
+    private Consumer<RestaurantReviewLike> cancelLike(RestaurantReview restaurantReview) {
+        restaurantReview.cancelLike();
         return restaurantReviewLikeRepository::delete;
     }
 
     private Runnable clickLike(RestaurantReview restaurantReview, OauthMember member) {
+        restaurantReview.clickLike();
         return () -> restaurantReviewLikeRepository.save(new RestaurantReviewLike(restaurantReview, member));
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
@@ -25,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class RestaurantReviewService {
 
-
     private final RestaurantRepository restaurantRepository;
     private final OauthMemberRepository oauthMemberRepository;
     private final RestaurantReviewRepository restaurantReviewRepository;
@@ -37,12 +36,12 @@ public class RestaurantReviewService {
         Restaurant restaurant = restaurantRepository.getById(command.restaurantId());
         RestaurantReview restaurantReview =
                 new RestaurantReview(command.content(), member, restaurant, command.rating(), 0);
-        saveReviewImagesIfExist(command.images(), restaurantReview);
+        saveReviewImages(command.images(), restaurantReview);
         restaurant.addReviewRating(restaurantReview.rating());
         return restaurantReviewRepository.save(restaurantReview).id();
     }
 
-    private void saveReviewImagesIfExist(List<MultipartFile> images, RestaurantReview review) {
+    private void saveReviewImages(List<MultipartFile> images, RestaurantReview review) {
         if (Objects.isNull(images)) {
             return;
         }

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
@@ -36,7 +36,7 @@ public class RestaurantReviewService {
         OauthMember member = oauthMemberRepository.getById(command.memberId());
         Restaurant restaurant = restaurantRepository.getById(command.restaurantId());
         RestaurantReview restaurantReview =
-                new RestaurantReview(command.content(), member, restaurant, command.rating());
+                new RestaurantReview(command.content(), member, restaurant, command.rating(), 0);
         saveReviewImagesIfExist(command.images(), restaurantReview);
         restaurant.addReviewRating(restaurantReview.rating());
         return restaurantReviewRepository.save(restaurantReview).id();

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
@@ -35,7 +35,7 @@ public class RestaurantReviewService {
         OauthMember member = oauthMemberRepository.getById(command.memberId());
         Restaurant restaurant = restaurantRepository.getById(command.restaurantId());
         RestaurantReview restaurantReview =
-                new RestaurantReview(command.content(), member, restaurant, command.rating(), 0);
+                new RestaurantReview(command.content(), member, restaurant, command.rating());
         saveReviewImages(command.images(), restaurantReview);
         restaurant.addReviewRating(restaurantReview.rating());
         return restaurantReviewRepository.save(restaurantReview).id();

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantReviewService.java
@@ -55,17 +55,12 @@ public class RestaurantReviewService {
 
     public void update(UpdateReviewRequestCommand command) {
         RestaurantReview review = restaurantReviewRepository.getById(command.reviewId());
-        Restaurant restaurant = review.restaurant();
-        restaurant.deleteReviewRating(review.rating());
-        review.updateContent(command.content(), command.memberId(), command.rating());
-        restaurant.addReviewRating(command.rating());
+        review.update(command.content(), command.memberId(), command.rating());
     }
 
     public void delete(DeleteReviewCommand command) {
         RestaurantReview review = restaurantReviewRepository.getById(command.reviewId());
-        review.checkOwner(command.memberId());
-        Restaurant restaurant = review.restaurant();
-        restaurant.deleteReviewRating(review.rating());
+        review.delete(command.memberId());
         restaurantReviewLikeRepository.deleteAllByRestaurantReview(review);
         restaurantReviewImageRepository.deleteAllByRestaurantReview(review);
         restaurantReviewRepository.delete(review);

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/dto/SaveReviewRequestCommand.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/dto/SaveReviewRequestCommand.java
@@ -10,4 +10,13 @@ public record SaveReviewRequestCommand(
         Double rating,
         List<MultipartFile> images
 ) {
+
+    public SaveReviewRequestCommand(
+            String content,
+            Long memberId,
+            Long restaurantId,
+            Double rating
+    ) {
+        this(content, memberId, restaurantId, rating, List.of());
+    }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/Restaurant.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/Restaurant.java
@@ -58,12 +58,12 @@ public class Restaurant extends BaseEntity {
         this.viewCount += 1;
     }
 
-    public void addReviewRating(Double rating) {
+    public void addReviewRating(double rating) {
         this.totalRating += rating;
         this.reviewCount += 1;
     }
 
-    public void deleteReviewRating(Double rating) {
+    public void deleteReviewRating(double rating) {
         this.totalRating -= rating;
         this.reviewCount -= 1;
     }

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
@@ -31,6 +31,8 @@ public class RestaurantReview extends BaseEntity {
 
     private Double rating;
 
+    private int likeCount;
+
     public void updateContent(String content, Long memberId, Double rating) {
         checkOwner(memberId);
         this.content = content;
@@ -41,6 +43,14 @@ public class RestaurantReview extends BaseEntity {
         if (!member.id().equals(memberId)) {
             throw new RestaurantReviewException(PERMISSION_DENIED);
         }
+    }
+
+    public void cancelLike() {
+        this.likeCount -= 1;
+    }
+
+    public void clickLike() {
+        this.likeCount += 1;
     }
 
     public String content() {
@@ -57,5 +67,9 @@ public class RestaurantReview extends BaseEntity {
 
     public Double rating() {
         return rating;
+    }
+
+    public int likeCount() {
+        return likeCount;
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
@@ -33,6 +33,10 @@ public class RestaurantReview extends BaseEntity {
 
     private int likeCount;
 
+    public RestaurantReview(String content, OauthMember member, Restaurant restaurant, Double rating) {
+        this(content, member, restaurant, rating, 0);
+    }
+
     public void updateContent(String content, Long memberId, Double rating) {
         checkOwner(memberId);
         this.content = content;

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReview.java
@@ -37,13 +37,20 @@ public class RestaurantReview extends BaseEntity {
         this(content, member, restaurant, rating, 0);
     }
 
-    public void updateContent(String content, Long memberId, Double rating) {
+    public void update(String content, Long memberId, Double updateRating) {
         checkOwner(memberId);
+        restaurant.deleteReviewRating(rating);
+        restaurant.addReviewRating(updateRating);
         this.content = content;
-        this.rating = rating;
+        this.rating = updateRating;
     }
 
-    public void checkOwner(Long memberId) {
+    public void delete(Long memberId) {
+        checkOwner(memberId);
+        restaurant.deleteReviewRating(rating);
+    }
+
+    private void checkOwner(Long memberId) {
         if (!member.id().equals(memberId)) {
             throw new RestaurantReviewException(PERMISSION_DENIED);
         }

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReviewRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/review/RestaurantReviewRepository.java
@@ -3,14 +3,9 @@ package com.celuveat.restaurant.command.domain.review;
 import static com.celuveat.restaurant.exception.RestaurantReviewExceptionType.NOT_FOUND_RESTAURANT_REVIEW;
 
 import com.celuveat.restaurant.exception.RestaurantReviewException;
-import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long> {
-
-    @EntityGraph(attributePaths = "member")
-    List<RestaurantReview> findAllByRestaurantIdOrderByCreatedDateDesc(Long restaurantId);
 
     default RestaurantReview getById(Long id) {
         return findById(id).orElseThrow(() -> new RestaurantReviewException(NOT_FOUND_RESTAURANT_REVIEW));

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/ReviewController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/ReviewController.java
@@ -3,6 +3,7 @@ package com.celuveat.restaurant.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.celuveat.common.auth.Auth;
+import com.celuveat.common.auth.LooseAuth;
 import com.celuveat.common.client.ImageUploadClient;
 import com.celuveat.restaurant.command.application.RestaurantReviewLikeService;
 import com.celuveat.restaurant.command.application.RestaurantReviewReportService;
@@ -39,9 +40,10 @@ public class ReviewController {
 
     @GetMapping
     ResponseEntity<RestaurantReviewQueryResponse> findAllReviewsByRestaurantId(
-            @RequestParam Long restaurantId
+            @RequestParam Long restaurantId,
+            @LooseAuth Long memberId
     ) {
-        return ResponseEntity.ok(restaurantReviewQueryService.findAllByRestaurantId(restaurantId));
+        return ResponseEntity.ok(restaurantReviewQueryService.findAllByRestaurantId(restaurantId, memberId));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/celuveat/restaurant/query/RestaurantReviewQueryService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/RestaurantReviewQueryService.java
@@ -13,7 +13,7 @@ public class RestaurantReviewQueryService {
 
     private final RestaurantReviewQueryResponseDao restaurantReviewQueryResponseDao;
 
-    public RestaurantReviewQueryResponse findAllByRestaurantId(Long restaurantId) {
-        return restaurantReviewQueryResponseDao.findAllByRestaurantId(restaurantId);
+    public RestaurantReviewQueryResponse findAllByRestaurantId(Long restaurantId, Long memberId) {
+        return restaurantReviewQueryResponseDao.findAllByRestaurantId(restaurantId, memberId);
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dao/RestaurantReviewQueryResponseDao.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dao/RestaurantReviewQueryResponseDao.java
@@ -5,10 +5,13 @@ import static com.celuveat.common.util.StreamUtil.groupBySameOrder;
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
 import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
 import com.celuveat.restaurant.query.dao.support.RestaurantReviewImageQueryDaoSupport;
+import com.celuveat.restaurant.query.dao.support.RestaurantReviewLikeQueryDaoSupport;
 import com.celuveat.restaurant.query.dao.support.RestaurantReviewQueryDaoSupport;
 import com.celuveat.restaurant.query.dto.RestaurantReviewQueryResponse;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,18 +22,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class RestaurantReviewQueryResponseDao {
 
     private final RestaurantReviewQueryDaoSupport restaurantReviewQueryDaoSupport;
+    private final RestaurantReviewLikeQueryDaoSupport restaurantReviewLikeQueryDaoSupport;
     private final RestaurantReviewImageQueryDaoSupport restaurantReviewImageQueryDaoSupport;
 
-    public RestaurantReviewQueryResponse findAllByRestaurantId(Long restaurantId) {
+    public RestaurantReviewQueryResponse findAllByRestaurantId(Long restaurantId, @Nullable Long memberId) {
         List<RestaurantReview> reviews =
                 restaurantReviewQueryDaoSupport.findAllByRestaurantIdOrderByCreatedDateDesc(restaurantId);
         Map<Long, List<RestaurantReviewImage>> imagesGroupByReviewId = getImagesGroupByReviewId(reviews);
-        return RestaurantReviewQueryResponse.from(reviews, imagesGroupByReviewId);
+        Map<Long, Boolean> isLikedByReviewId = getReviewLikedGroupByReviewId(reviews, memberId);
+        return RestaurantReviewQueryResponse.from(reviews, imagesGroupByReviewId, isLikedByReviewId);
     }
 
     private Map<Long, List<RestaurantReviewImage>> getImagesGroupByReviewId(List<RestaurantReview> reviews) {
         List<RestaurantReviewImage> restaurantReviewImages
                 = restaurantReviewImageQueryDaoSupport.findAllByRestaurantReviewIn(reviews);
         return groupBySameOrder(restaurantReviewImages, image -> image.restaurantReview().id());
+    }
+
+    private Map<Long, Boolean> getReviewLikedGroupByReviewId(
+            List<RestaurantReview> reviews,
+            Long memberId
+    ) {
+        return reviews.stream().collect(Collectors.toMap(
+                RestaurantReview::id,
+                review -> restaurantReviewLikeQueryDaoSupport.findByRestaurantReviewAndMemberId(review, memberId)
+                        .isPresent()
+        ));
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dao/RestaurantReviewQueryResponseDao.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dao/RestaurantReviewQueryResponseDao.java
@@ -1,9 +1,14 @@
 package com.celuveat.restaurant.query.dao;
 
+import static com.celuveat.common.util.StreamUtil.groupBySameOrder;
+
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
-import com.celuveat.restaurant.command.domain.review.RestaurantReviewRepository;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
+import com.celuveat.restaurant.query.dao.support.RestaurantReviewImageQueryDaoSupport;
+import com.celuveat.restaurant.query.dao.support.RestaurantReviewQueryDaoSupport;
 import com.celuveat.restaurant.query.dto.RestaurantReviewQueryResponse;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +18,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RestaurantReviewQueryResponseDao {
 
-    private final RestaurantReviewRepository restaurantReviewRepository;
+    private final RestaurantReviewQueryDaoSupport restaurantReviewQueryDaoSupport;
+    private final RestaurantReviewImageQueryDaoSupport restaurantReviewImageQueryDaoSupport;
 
     public RestaurantReviewQueryResponse findAllByRestaurantId(Long restaurantId) {
         List<RestaurantReview> reviews =
-                restaurantReviewRepository.findAllByRestaurantIdOrderByCreatedDateDesc(restaurantId);
-        return RestaurantReviewQueryResponse.from(reviews);
+                restaurantReviewQueryDaoSupport.findAllByRestaurantIdOrderByCreatedDateDesc(restaurantId);
+        Map<Long, List<RestaurantReviewImage>> imagesGroupByReviewId = getImagesGroupByReviewId(reviews);
+        return RestaurantReviewQueryResponse.from(reviews, imagesGroupByReviewId);
+    }
+
+    private Map<Long, List<RestaurantReviewImage>> getImagesGroupByReviewId(List<RestaurantReview> reviews) {
+        List<RestaurantReviewImage> restaurantReviewImages
+                = restaurantReviewImageQueryDaoSupport.findAllByRestaurantReviewIn(reviews);
+        return groupBySameOrder(restaurantReviewImages, image -> image.restaurantReview().id());
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewImageQueryDaoSupport.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewImageQueryDaoSupport.java
@@ -1,0 +1,11 @@
+package com.celuveat.restaurant.query.dao.support;
+
+import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantReviewImageQueryDaoSupport extends JpaRepository<RestaurantReviewImage, Long> {
+
+    List<RestaurantReviewImage> findAllByRestaurantReviewIn(List<RestaurantReview> reviews);
+}

--- a/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewLikeQueryDaoSupport.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewLikeQueryDaoSupport.java
@@ -1,0 +1,11 @@
+package com.celuveat.restaurant.query.dao.support;
+
+import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantReviewLikeQueryDaoSupport extends JpaRepository<RestaurantReviewLike, Long> {
+
+    Optional<RestaurantReviewLike> findByRestaurantReviewAndMemberId(RestaurantReview restaurantReview, Long memberId);
+}

--- a/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewQueryDaoSupport.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dao/support/RestaurantReviewQueryDaoSupport.java
@@ -1,0 +1,12 @@
+package com.celuveat.restaurant.query.dao.support;
+
+import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantReviewQueryDaoSupport extends JpaRepository<RestaurantReview, Long> {
+
+    @EntityGraph(attributePaths = "member")
+    List<RestaurantReview> findAllByRestaurantIdOrderByCreatedDateDesc(Long restaurantId);
+}

--- a/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewQueryResponse.java
@@ -12,14 +12,15 @@ public record RestaurantReviewQueryResponse(
 
     public static RestaurantReviewQueryResponse from(
             List<RestaurantReview> restaurantReviews,
-            Map<Long, List<RestaurantReviewImage>> restaurantReviewImages
+            Map<Long, List<RestaurantReviewImage>> restaurantReviewImages,
+            Map<Long, Boolean> isLikedByReviewId
     ) {
         List<RestaurantReviewSingleResponse> reviews = restaurantReviews.stream()
                 .map(review -> RestaurantReviewSingleResponse.of(
                         review,
-                        restaurantReviewImages.getOrDefault(review.id(), List.of()))
-                )
-                .toList();
+                        restaurantReviewImages.getOrDefault(review.id(), List.of()),
+                        isLikedByReviewId.getOrDefault(review.id(), false)
+                )).toList();
         return new RestaurantReviewQueryResponse(reviews.size(), reviews);
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewQueryResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewQueryResponse.java
@@ -1,16 +1,24 @@
 package com.celuveat.restaurant.query.dto;
 
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
 import java.util.List;
+import java.util.Map;
 
 public record RestaurantReviewQueryResponse(
         Integer totalElementsCount,
         List<RestaurantReviewSingleResponse> reviews
 ) {
 
-    public static RestaurantReviewQueryResponse from(List<RestaurantReview> restaurantReviews) {
+    public static RestaurantReviewQueryResponse from(
+            List<RestaurantReview> restaurantReviews,
+            Map<Long, List<RestaurantReviewImage>> restaurantReviewImages
+    ) {
         List<RestaurantReviewSingleResponse> reviews = restaurantReviews.stream()
-                .map(RestaurantReviewSingleResponse::from)
+                .map(review -> RestaurantReviewSingleResponse.of(
+                        review,
+                        restaurantReviewImages.getOrDefault(review.id(), List.of()))
+                )
                 .toList();
         return new RestaurantReviewQueryResponse(reviews.size(), reviews);
     }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewSingleResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewSingleResponse.java
@@ -2,6 +2,8 @@ package com.celuveat.restaurant.query.dto;
 
 import com.celuveat.auth.command.domain.OauthMember;
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
+import java.util.List;
 
 public record RestaurantReviewSingleResponse(
         Long id,
@@ -9,10 +11,15 @@ public record RestaurantReviewSingleResponse(
         String nickname,
         String profileImageUrl,
         String content,
-        String createdDate
+        String createdDate,
+        Double rating,
+        List<String> images
 ) {
 
-    public static RestaurantReviewSingleResponse from(RestaurantReview restaurantReview) {
+    public static RestaurantReviewSingleResponse of(
+            RestaurantReview restaurantReview,
+            List<RestaurantReviewImage> images
+    ) {
         OauthMember oauthMember = restaurantReview.member();
         return new RestaurantReviewSingleResponse(
                 restaurantReview.id(),
@@ -20,7 +27,9 @@ public record RestaurantReviewSingleResponse(
                 oauthMember.nickname(),
                 oauthMember.profileImageUrl(),
                 restaurantReview.content(),
-                restaurantReview.createdDate().toLocalDate().toString()
+                restaurantReview.createdDate().toLocalDate().toString(),
+                restaurantReview.rating(),
+                images.stream().map(RestaurantReviewImage::name).toList()
         );
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewSingleResponse.java
+++ b/backend/src/main/java/com/celuveat/restaurant/query/dto/RestaurantReviewSingleResponse.java
@@ -12,13 +12,16 @@ public record RestaurantReviewSingleResponse(
         String profileImageUrl,
         String content,
         String createdDate,
+        Integer likeCount,
+        Boolean isLiked,
         Double rating,
         List<String> images
 ) {
 
     public static RestaurantReviewSingleResponse of(
             RestaurantReview restaurantReview,
-            List<RestaurantReviewImage> images
+            List<RestaurantReviewImage> images,
+            boolean isLiked
     ) {
         OauthMember oauthMember = restaurantReview.member();
         return new RestaurantReviewSingleResponse(
@@ -28,6 +31,8 @@ public record RestaurantReviewSingleResponse(
                 oauthMember.profileImageUrl(),
                 restaurantReview.content(),
                 restaurantReview.createdDate().toLocalDate().toString(),
+                restaurantReview.likeCount(),
+                isLiked,
                 restaurantReview.rating(),
                 images.stream().map(RestaurantReviewImage::name).toList()
         );

--- a/backend/src/test/java/com/celuveat/acceptance/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/common/AcceptanceTest.java
@@ -3,6 +3,8 @@ package com.celuveat.acceptance.common;
 import static com.celuveat.acceptance.common.AcceptanceSteps.로그인을_요청한다;
 import static com.celuveat.acceptance.common.AcceptanceSteps.세션_아이디를_가져온다;
 import static com.celuveat.auth.command.domain.OauthServerType.KAKAO;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import com.celuveat.auth.command.application.OauthService;
 import com.celuveat.auth.command.domain.OauthMember;
@@ -24,8 +26,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.mockito.BDDMockito;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -41,6 +41,7 @@ public abstract class AcceptanceTest {
 
     @MockBean
     protected OauthService oauthService;
+
     @MockBean
     protected ImageUploadClient imageUploadClient;
 
@@ -88,10 +89,10 @@ public abstract class AcceptanceTest {
     }
 
     private void OAuth_응답을_설정한다(OauthMember member) {
-        Mockito.when(oauthService.login(KAKAO, "abcd")).thenReturn(member.id());
+        given(oauthService.login(KAKAO, "abcd")).willReturn(member.id());
     }
 
     protected void 이미지_업로드를_설정한다(List<MultipartFile> images) {
-        BDDMockito.willDoNothing().given(imageUploadClient).upload(images);
+        willDoNothing().given(imageUploadClient).upload(images);
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
@@ -136,7 +136,7 @@ public class RestaurantReviewAcceptanceSteps {
                 .isEqualTo(예상_응답);
     }
 
-    public static MockMultipartFile 이미지를_생성한다(final String name, final String originalFilename) {
+    public static MultipartFile 이미지를_생성한다(final String name, final String originalFilename) {
         return new MockMultipartFile(
                 name, originalFilename, "multipart/form-data", originalFilename.getBytes()
         );

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
@@ -96,6 +96,14 @@ public class RestaurantReviewAcceptanceSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 리뷰_조회_요청을_보낸다(Long 음식점_아이디, String 세션_아이디) {
+        return given(세션_아이디)
+                .queryParam("restaurantId", 음식점_아이디)
+                .when().get("/reviews")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 리뷰_수정_요청을_보낸다(
             UpdateReviewRequest 요청,
             String 세션_아이디,

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
@@ -34,10 +34,10 @@ public class RestaurantReviewAcceptanceSteps {
 
     public static RestaurantReviewQueryResponse 예상_응답(Long 말랑_아이디, Long 로이스_아이디, Long 도기_아이디) {
         return new RestaurantReviewQueryResponse(4, List.of(
-                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰4", null, 5.0, null),
-                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰3", null, 5.0, null),
-                new RestaurantReviewSingleResponse(null, 로이스_아이디, "로이스", "abc", "리뷰2", null, 5.0, null),
-                new RestaurantReviewSingleResponse(null, 도기_아이디, "도기", "abc", "리뷰1", null, 5.0, null)
+                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰4", null, 0, false, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰3", null, 0, false, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 로이스_아이디, "로이스", "abc", "리뷰2", null, 0, false, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 도기_아이디, "도기", "abc", "리뷰1", null, 0, false, 5.0, null)
         ));
     }
 

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
@@ -11,6 +11,7 @@ import com.celuveat.restaurant.query.dto.RestaurantReviewSingleResponse;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import io.restassured.specification.MultiPartSpecification;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -33,10 +34,10 @@ public class RestaurantReviewAcceptanceSteps {
 
     public static RestaurantReviewQueryResponse 예상_응답(Long 말랑_아이디, Long 로이스_아이디, Long 도기_아이디) {
         return new RestaurantReviewQueryResponse(4, List.of(
-                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰4", null),
-                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰3", null),
-                new RestaurantReviewSingleResponse(null, 로이스_아이디, "로이스", "abc", "리뷰2", null),
-                new RestaurantReviewSingleResponse(null, 도기_아이디, "도기", "abc", "리뷰1", null)
+                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰4", null, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 말랑_아이디, "말랑", "abc", "리뷰3", null, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 로이스_아이디, "로이스", "abc", "리뷰2", null, 5.0, null),
+                new RestaurantReviewSingleResponse(null, 도기_아이디, "도기", "abc", "리뷰1", null, 5.0, null)
         ));
     }
 
@@ -61,8 +62,8 @@ public class RestaurantReviewAcceptanceSteps {
         var restaurantId =
                 new MultiPartSpecBuilder(요청.restaurantId()).controlName("restaurantId").charset(UTF_8).build();
         var rating = new MultiPartSpecBuilder(요청.rating()).controlName("rating").charset(UTF_8).build();
-        var imagesA = new MultiPartSpecBuilder(요청.images().get(0).getBytes()).controlName("images").build();
-        var imagesB = new MultiPartSpecBuilder(요청.images().get(1).getBytes()).controlName("images").build();
+        var imagesA = 멀티파트_스팩을_추출한다(요청, 0);
+        var imagesB = 멀티파트_스팩을_추출한다(요청, 1);
         return given(세션_아이디)
                 .multiPart(content)
                 .multiPart(restaurantId)
@@ -73,6 +74,18 @@ public class RestaurantReviewAcceptanceSteps {
                 .when().post("/reviews")
                 .then().log().all()
                 .extract();
+    }
+
+    private static MultiPartSpecification 멀티파트_스팩을_추출한다(
+            SaveReviewRequest 요청,
+            int index
+    ) throws IOException {
+        var image = 요청.images().get(index);
+        return new MultiPartSpecBuilder(image.getBytes())
+                .controlName("images")
+                .fileName(image.getOriginalFilename())
+                .charset(UTF_8)
+                .build();
     }
 
     public static ExtractableResponse<Response> 리뷰_조회_요청을_보낸다(Long 음식점_아이디) {

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
@@ -15,6 +15,7 @@ import static com.celuveat.acceptance.restaurant.RestaurantReviewAcceptanceSteps
 import static com.celuveat.acceptance.restaurant.RestaurantReviewAcceptanceSteps.예상_응답;
 import static com.celuveat.acceptance.restaurant.RestaurantReviewAcceptanceSteps.응답을_검증한다;
 import static com.celuveat.acceptance.restaurant.RestaurantReviewAcceptanceSteps.이미지를_생성한다;
+import static com.celuveat.acceptance.restaurant.RestaurantReviewLikeAcceptanceSteps.좋아요_요청을_보낸다;
 import static com.celuveat.auth.fixture.OauthMemberFixture.멤버;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.음식점;
 import static com.celuveat.restaurant.fixture.RestaurantReviewFixture.음식점_리뷰;
@@ -164,6 +165,27 @@ public class RestaurantReviewAcceptanceTest extends AcceptanceTest {
 
         // when
         var 응답 = 리뷰_조회_요청을_보낸다(음식점.id());
+
+        // then
+        응답_상태를_검증한다(응답, 정상_처리);
+    }
+
+    @Test
+    void 로그인후_리뷰를_조회시_좋아요_여부가_반영된다() {
+        // given
+        var 음식점 = 음식점("오도음식점");
+        음식점을_저장한다(음식점);
+        var 오도 = 멤버("오도");
+        회원가입하고_로그인한다(오도);
+        var 리뷰_아이디 = 음식점_리뷰를_저장한다(음식점_리뷰(오도, 음식점));
+        음식점_리뷰를_저장한다(음식점_리뷰(오도, 음식점));
+
+        var 로이스 = 멤버("로이스");
+        var 로이스_세션_아이디 = 회원가입하고_로그인한다(로이스);
+        좋아요_요청을_보낸다(리뷰_아이디, 로이스_세션_아이디);
+
+        // when
+        var 응답 = 리뷰_조회_요청을_보낸다(음식점.id(), 로이스_세션_아이디);
 
         // then
         응답_상태를_검증한다(응답, 정상_처리);

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
@@ -134,13 +134,13 @@ public class RestaurantReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 음식점_리뷰에_사진을_첨부한다_작성한다() throws IOException {
+    void 음식점_리뷰에_사진을_첨부하여_작성한다() throws IOException {
         // given
         var 음식점 = 음식점("오도음식점");
         음식점을_저장한다(음식점);
         var 오도 = 멤버("오도");
         var 세션_아이디 = 회원가입하고_로그인한다(오도);
-        List<MultipartFile> 리뷰_이미지 = List.of(이미지를_생성한다("images", "이미지1번.wepb"), 이미지를_생성한다("images", "이미지1번.wepb"));
+        var 리뷰_이미지 = List.of(이미지를_생성한다("images", "이미지1번.wepb"), 이미지를_생성한다("images", "이미지1번.wepb"));
         이미지_업로드를_설정한다(리뷰_이미지);
         var 요청 = 리뷰_요청("맛집이네요 또 올 것 같습니다", 음식점.id(), 5.0, 리뷰_이미지);
 

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceTest.java
@@ -149,4 +149,23 @@ public class RestaurantReviewAcceptanceTest extends AcceptanceTest {
         // then
         응답_상태를_검증한다(응답, 생성됨);
     }
+
+    @Test
+    void 사진이_포함된_리뷰를_조회한다() throws IOException {
+        // given
+        var 음식점 = 음식점("오도음식점");
+        음식점을_저장한다(음식점);
+        var 오도 = 멤버("오도");
+        var 세션_아이디 = 회원가입하고_로그인한다(오도);
+        List<MultipartFile> 리뷰_이미지 = List.of(이미지를_생성한다("images", "image1.wepb"), 이미지를_생성한다("images", "image2.wepb"));
+        이미지_업로드를_설정한다(리뷰_이미지);
+        var 요청 = 리뷰_요청("맛집이네요 또 올 것 같습니다", 음식점.id(), 5.0, 리뷰_이미지);
+        사진_2장이_포함된_리뷰_작성_요청을_보낸다(요청, 세션_아이디);
+
+        // when
+        var 응답 = 리뷰_조회_요청을_보낸다(음식점.id());
+
+        // then
+        응답_상태를_검증한다(응답, 정상_처리);
+    }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewLikeServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewLikeServiceTest.java
@@ -106,4 +106,44 @@ class RestaurantReviewLikeServiceTest {
                 restaurantReviewLikeRepository.findByRestaurantReviewAndMember(음식점_리뷰, 로이스);
         assertThat(result).isEmpty();
     }
+
+    @Test
+    void 좋아요를_추가되면_리뷰의_좋아요_개수가_증가한다() {
+        // given
+        Restaurant 음식점 = 음식점("음식점");
+        OauthMember 말랑 = 멤버("말랑");
+        RestaurantReview 음식점_리뷰 = 음식점_리뷰(말랑, 음식점);
+        OauthMember 로이스 = 멤버("로이스");
+        restaurantRepository.save(음식점);
+        oauthMemberRepository.save(말랑);
+        restaurantReviewRepository.save(음식점_리뷰);
+        oauthMemberRepository.save(로이스);
+
+        // when
+        restaurantReviewLikeService.like(음식점_리뷰.id(), 로이스.id());
+
+        // then
+        assertThat(음식점_리뷰.likeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 좋아요를_삭제되면_리뷰의_좋아요_개수가_증가한다() {
+        // given
+        Restaurant 음식점 = 음식점("음식점");
+        OauthMember 말랑 = 멤버("말랑");
+        RestaurantReview 음식점_리뷰 = 음식점_리뷰(말랑, 음식점);
+        OauthMember 로이스 = 멤버("로이스");
+        restaurantRepository.save(음식점);
+        oauthMemberRepository.save(말랑);
+        restaurantReviewRepository.save(음식점_리뷰);
+        oauthMemberRepository.save(로이스);
+        restaurantReviewLikeService.like(음식점_리뷰.id(), 로이스.id());
+        assertThat(음식점_리뷰.likeCount()).isEqualTo(1);
+
+        // when
+        restaurantReviewLikeService.like(음식점_리뷰.id(), 로이스.id());
+
+        // then
+        assertThat(음식점_리뷰.likeCount()).isEqualTo(0);
+    }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
@@ -135,7 +135,7 @@ class RestaurantReviewServiceTest {
         Long reviewId = restaurantReviewService.create(saveCommand);
         UpdateReviewRequestCommand updateCommand =
                 new UpdateReviewRequestCommand("사장님이 초심을 잃었어요!", reviewId, member.id(), 0.0);
-        RestaurantReview expected = new RestaurantReview("사장님이 초심을 잃었어요!", member, restaurant, 0.0, 0);
+        RestaurantReview expected = new RestaurantReview("사장님이 초심을 잃었어요!", member, restaurant, 0.0);
 
         // when
         restaurantReviewService.update(updateCommand);
@@ -229,7 +229,7 @@ class RestaurantReviewServiceTest {
         SaveReviewRequestCommand command =
                 new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, images);
         willDoNothing().given(imageUploadClient).upload(images);
-        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0, 0);
+        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0);
 
         // when
         Long reviewId = restaurantReviewService.create(command);

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
@@ -79,7 +79,7 @@ class RestaurantReviewServiceTest {
         // given
         SaveReviewRequestCommand command =
                 new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
-        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0);
+        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0, 0);
 
         // when
         Long reviewId = restaurantReviewService.create(command);
@@ -135,7 +135,7 @@ class RestaurantReviewServiceTest {
         Long reviewId = restaurantReviewService.create(saveCommand);
         UpdateReviewRequestCommand updateCommand =
                 new UpdateReviewRequestCommand("사장님이 초심을 잃었어요!", reviewId, member.id(), 0.0);
-        RestaurantReview expected = new RestaurantReview("사장님이 초심을 잃었어요!", member, restaurant, 0.0);
+        RestaurantReview expected = new RestaurantReview("사장님이 초심을 잃었어요!", member, restaurant, 0.0, 0);
 
         // when
         restaurantReviewService.update(updateCommand);
@@ -229,7 +229,7 @@ class RestaurantReviewServiceTest {
         SaveReviewRequestCommand command =
                 new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, images);
         willDoNothing().given(imageUploadClient).upload(images);
-        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0);
+        RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0, 0);
 
         // when
         Long reviewId = restaurantReviewService.create(command);

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantReviewServiceTest.java
@@ -78,7 +78,7 @@ class RestaurantReviewServiceTest {
     void 리뷰를_저장한다() {
         // given
         SaveReviewRequestCommand command =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         RestaurantReview expected = new RestaurantReview("정말 맛있어요", member, restaurant, 5.0, 0);
 
         // when
@@ -95,9 +95,9 @@ class RestaurantReviewServiceTest {
     void 리뷰를_저장하면_음식점에_전체_평점과_리뷰수를_증가시킨다() {
         // given
         SaveReviewRequestCommand commandA =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         SaveReviewRequestCommand commandB =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 3.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 3.0);
 
         // when
         restaurantReviewService.create(commandA);
@@ -113,7 +113,7 @@ class RestaurantReviewServiceTest {
     void 다른_사람의_리뷰를_수정하려하면_예외가_발생한다() {
         // given
         SaveReviewRequestCommand saveCommand =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommand);
         UpdateReviewRequestCommand updateCommand =
                 new UpdateReviewRequestCommand("더 맛있어졌어요", reviewId, otherMember.id(), 5.0);
@@ -131,7 +131,7 @@ class RestaurantReviewServiceTest {
     void 리뷰를_수정한다() {
         // given
         SaveReviewRequestCommand saveCommand =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommand);
         UpdateReviewRequestCommand updateCommand =
                 new UpdateReviewRequestCommand("사장님이 초심을 잃었어요!", reviewId, member.id(), 0.0);
@@ -152,10 +152,10 @@ class RestaurantReviewServiceTest {
     void 리뷰를_수정하면_음식점의_전체_평점이_변경된다() {
         // given
         SaveReviewRequestCommand saveCommandA =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         restaurantReviewService.create(saveCommandA);
         SaveReviewRequestCommand saveCommandB =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommandB);
         UpdateReviewRequestCommand updateCommand =
                 new UpdateReviewRequestCommand("사장님이 초심을 잃었어요!", reviewId, member.id(), 1.0);
@@ -174,7 +174,7 @@ class RestaurantReviewServiceTest {
     void 다른_사람의_리뷰를_삭제하려하면_예외가_발생한다() {
         // given
         SaveReviewRequestCommand saveCommand =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommand);
         DeleteReviewCommand deleteCommand = new DeleteReviewCommand(reviewId, otherMember.id());
 
@@ -191,7 +191,7 @@ class RestaurantReviewServiceTest {
     void 리뷰를_삭제한다() {
         // given
         SaveReviewRequestCommand saveCommand =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommand);
         DeleteReviewCommand deleteCommand = new DeleteReviewCommand(reviewId, member.id());
 
@@ -207,7 +207,7 @@ class RestaurantReviewServiceTest {
     void 리뷰를_삭제하면_음식점의_전체_평점과_리뷰수가_감소한다() {
         // given
         SaveReviewRequestCommand saveCommand =
-                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0, null);
+                new SaveReviewRequestCommand("정말 맛있어요", member.id(), restaurant.id(), 5.0);
         Long reviewId = restaurantReviewService.create(saveCommand);
         DeleteReviewCommand deleteCommand = new DeleteReviewCommand(reviewId, member.id());
 

--- a/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
+++ b/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
@@ -7,6 +7,6 @@ import com.celuveat.restaurant.command.domain.review.RestaurantReview;
 public class RestaurantReviewFixture {
 
     public static RestaurantReview 음식점_리뷰(OauthMember member, Restaurant restaurant) {
-        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5D);
+        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5.0);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
+++ b/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
@@ -7,6 +7,6 @@ import com.celuveat.restaurant.command.domain.review.RestaurantReview;
 public class RestaurantReviewFixture {
 
     public static RestaurantReview 음식점_리뷰(OauthMember member, Restaurant restaurant) {
-        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5.0, 0);
+        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5.0);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
+++ b/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewFixture.java
@@ -7,6 +7,6 @@ import com.celuveat.restaurant.command.domain.review.RestaurantReview;
 public class RestaurantReviewFixture {
 
     public static RestaurantReview 음식점_리뷰(OauthMember member, Restaurant restaurant) {
-        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5.0);
+        return new RestaurantReview(member.nickname() + "," + restaurant.name(), member, restaurant, 5.0, 0);
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewImageFixture.java
+++ b/backend/src/test/java/com/celuveat/restaurant/fixture/RestaurantReviewImageFixture.java
@@ -1,0 +1,21 @@
+package com.celuveat.restaurant.fixture;
+
+import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RestaurantReviewImageFixture {
+
+    public static RestaurantReviewImage 리뷰_사진(String 사진_이름, RestaurantReview 리뷰) {
+        return new RestaurantReviewImage(사진_이름, 리뷰);
+    }
+
+    public static List<RestaurantReviewImage> 리뷰의_사진들(RestaurantReview 리뷰) {
+        List<RestaurantReviewImage> restaurantReviewImages = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            restaurantReviewImages.add(리뷰_사진(리뷰.content() + "_" + i, 리뷰));
+        }
+        return restaurantReviewImages;
+    }
+}

--- a/backend/src/test/java/com/celuveat/restaurant/query/RestaurantReviewQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/query/RestaurantReviewQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.celuveat.restaurant.query;
 import static com.celuveat.auth.fixture.OauthMemberFixture.멤버;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.음식점;
 import static com.celuveat.restaurant.fixture.RestaurantReviewFixture.음식점_리뷰;
+import static com.celuveat.restaurant.fixture.RestaurantReviewImageFixture.리뷰의_사진들;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.celuveat.auth.command.domain.OauthMember;
@@ -11,9 +12,12 @@ import com.celuveat.common.IntegrationTest;
 import com.celuveat.restaurant.command.domain.Restaurant;
 import com.celuveat.restaurant.command.domain.RestaurantRepository;
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewImageRepository;
 import com.celuveat.restaurant.command.domain.review.RestaurantReviewRepository;
 import com.celuveat.restaurant.query.dto.RestaurantReviewQueryResponse;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -30,6 +34,9 @@ class RestaurantReviewQueryServiceTest {
 
     @Autowired
     private RestaurantReviewRepository restaurantReviewRepository;
+
+    @Autowired
+    private RestaurantReviewImageRepository restaurantReviewImageRepository;
 
     @Autowired
     private RestaurantRepository restaurantRepository;
@@ -54,10 +61,15 @@ class RestaurantReviewQueryServiceTest {
         RestaurantReview review3 = 음식점_리뷰(member3, restaurant);
         RestaurantReview review4 = 음식점_리뷰(member3, restaurant);
         restaurantReviewRepository.saveAll(List.of(review1, review2, review3, review4));
-
+        Map<Long, List<RestaurantReviewImage>> 리뷰_사진들 = Map.of(
+                review1.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review1)),
+                review2.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review2)),
+                review3.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review3)),
+                review4.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review4))
+        );
         RestaurantReviewQueryResponse expected = RestaurantReviewQueryResponse.from(List.of(
                 review4, review3, review2, review1
-        ));
+        ), 리뷰_사진들);
 
         // when
         RestaurantReviewQueryResponse result =

--- a/backend/src/test/java/com/celuveat/restaurant/query/RestaurantReviewQueryServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/query/RestaurantReviewQueryServiceTest.java
@@ -14,6 +14,8 @@ import com.celuveat.restaurant.command.domain.RestaurantRepository;
 import com.celuveat.restaurant.command.domain.review.RestaurantReview;
 import com.celuveat.restaurant.command.domain.review.RestaurantReviewImage;
 import com.celuveat.restaurant.command.domain.review.RestaurantReviewImageRepository;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewLike;
+import com.celuveat.restaurant.command.domain.review.RestaurantReviewLikeRepository;
 import com.celuveat.restaurant.command.domain.review.RestaurantReviewRepository;
 import com.celuveat.restaurant.query.dto.RestaurantReviewQueryResponse;
 import java.util.List;
@@ -37,6 +39,9 @@ class RestaurantReviewQueryServiceTest {
 
     @Autowired
     private RestaurantReviewImageRepository restaurantReviewImageRepository;
+
+    @Autowired
+    private RestaurantReviewLikeRepository restaurantReviewLikeRepository;
 
     @Autowired
     private RestaurantRepository restaurantRepository;
@@ -69,11 +74,45 @@ class RestaurantReviewQueryServiceTest {
         );
         RestaurantReviewQueryResponse expected = RestaurantReviewQueryResponse.from(List.of(
                 review4, review3, review2, review1
-        ), 리뷰_사진들);
+        ), 리뷰_사진들, Map.of());
 
         // when
         RestaurantReviewQueryResponse result =
-                restaurantReviewQueryService.findAllByRestaurantId(restaurant.id());
+                restaurantReviewQueryService.findAllByRestaurantId(restaurant.id(), null);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void 음식점_리뷰를_조회_할때_좋아요_여부가_포함_된다() {
+        // given
+        Restaurant restaurant = 음식점("오도음식점");
+        restaurantRepository.save(restaurant);
+        OauthMember member1 = 멤버("도기");
+        oauthMemberRepository.save(member1);
+        OauthMember member2 = 멤버("말랑");
+        oauthMemberRepository.save(member2);
+
+        RestaurantReview review1 = 음식점_리뷰(member1, restaurant);
+        RestaurantReview review2 = 음식점_리뷰(member2, restaurant);
+        restaurantReviewRepository.saveAll(List.of(review1, review2));
+        Map<Long, List<RestaurantReviewImage>> 리뷰_사진들 = Map.of(
+                review1.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review1)),
+                review2.id(), restaurantReviewImageRepository.saveAll(리뷰의_사진들(review2))
+        );
+        restaurantReviewLikeRepository.save(new RestaurantReviewLike(review1, member1));
+        Map<Long, Boolean> 리뷰_좋아요_여부 = Map.of(
+                review1.id(), true,
+                review2.id(), false
+        );
+        RestaurantReviewQueryResponse expected = RestaurantReviewQueryResponse.from(List.of(
+                review2, review1
+        ), 리뷰_사진들, 리뷰_좋아요_여부);
+
+        // when
+        RestaurantReviewQueryResponse result =
+                restaurantReviewQueryService.findAllByRestaurantId(restaurant.id(), member1.id());
 
         // then
         assertThat(result).isEqualTo(expected);


### PR DESCRIPTION
## ✨ 요약
```
리뷰 조회시 이미지, 평점, 좋아요 여부를 포함하여 응답합니다
```

### schema 변경사항
`reataurant_review` -> `like_count` 컬럼 추가
```sql
ALTER TABLE restaurant_review ADD COLUMN (like_count INT);
UPDATE restaurant_review SET restaurant_review.like_count = 0 WHERE restaurant_review.like_count IS NULL;
```
---

- #550 위에서 작업하였습니다.

<br>

[리뷰 범위 입니다!](https://github.com/woowacourse-teams/2023-celuveat/pull/553/files/4c38650c29a697411539e361918ad04a02ae0370..6c2e39c694c676a0253af8433fa384c87c172265)

## 😎 해결한 이슈
- close #552 
