### PR TITLE
feat: 음식점 사진 추가 api 구현

### DIFF
--- a/backend/src/main/java/com/celuveat/admin/command/application/AdminService.java
+++ b/backend/src/main/java/com/celuveat/admin/command/application/AdminService.java
@@ -4,6 +4,7 @@ import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_DATE_FORMA
 import static com.celuveat.admin.exception.AdminExceptionType.MISMATCH_COUNT_IMAGE_NAME_AND_INSTAGRAM_NAME;
 import static com.celuveat.admin.exception.AdminExceptionType.MISMATCH_COUNT_YOUTUBE_VIDEO_LINK_AND_UPLOAD_DATE;
 
+import com.celuveat.admin.command.application.dto.SaveImageCommand;
 import com.celuveat.admin.exception.AdminException;
 import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
@@ -13,6 +14,7 @@ import com.celuveat.restaurant.command.domain.Restaurant;
 import com.celuveat.restaurant.command.domain.RestaurantImage;
 import com.celuveat.restaurant.command.domain.RestaurantImageRepository;
 import com.celuveat.restaurant.command.domain.RestaurantRepository;
+import com.celuveat.restaurant.command.domain.SocialMedia;
 import com.celuveat.video.command.domain.Video;
 import com.celuveat.video.command.domain.VideoRepository;
 import java.time.LocalDate;
@@ -104,5 +106,16 @@ public class AdminService {
                 .map(SaveCelebRequest::toCeleb)
                 .toList();
         celebRepository.saveAll(celebs);
+    }
+
+    public Long saveImage(SaveImageCommand command) {
+        Restaurant restaurant = restaurantRepository.getById(command.restaurantId());
+        RestaurantImage restaurantImage = RestaurantImage.builder()
+                .name(command.name())
+                .author(command.author())
+                .socialMedia(SocialMedia.from(command.socialMedia()))
+                .restaurant(restaurant)
+                .build();
+        return restaurantImageRepository.save(restaurantImage).id();
     }
 }

--- a/backend/src/main/java/com/celuveat/admin/command/application/dto/SaveImageCommand.java
+++ b/backend/src/main/java/com/celuveat/admin/command/application/dto/SaveImageCommand.java
@@ -1,0 +1,9 @@
+package com.celuveat.admin.command.application.dto;
+
+public record SaveImageCommand(
+        Long restaurantId,
+        String author,
+        String name,
+        String socialMedia
+) {
+}

--- a/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
@@ -1,14 +1,19 @@
 package com.celuveat.admin.presentation;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import com.celuveat.admin.command.application.AdminService;
 import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
+import com.celuveat.admin.presentation.dto.SaveImageRequest;
+import com.celuveat.common.client.ImageUploadClient;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +27,7 @@ public class AdminController {
 
     static final String TAB = "\t";
 
+    private final ImageUploadClient imageUploadClient;
     private final AdminService adminService;
 
     @PostMapping("/data")
@@ -36,6 +42,13 @@ public class AdminController {
         List<SaveCelebRequest> request = toRequest(rawData, SaveCelebRequest::new);
         adminService.saveCelebs(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/images")
+    ResponseEntity<Void> uploadImage(@ModelAttribute SaveImageRequest request) {
+        imageUploadClient.upload(request.image());
+        adminService.saveImage(request.toCommand());
+        return ResponseEntity.status(CREATED).build();
     }
 
     private <T> List<T> toRequest(String rawData, Function<String[], T> function) {

--- a/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/AdminController.java
@@ -44,7 +44,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/images")
+    @PostMapping("/restaurant-images")
     ResponseEntity<Void> uploadImage(@ModelAttribute SaveImageRequest request) {
         imageUploadClient.upload(request.image());
         adminService.saveImage(request.toCommand());

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveDataRequest.java
@@ -1,5 +1,8 @@
 package com.celuveat.admin.presentation.dto;
 
+import static com.celuveat.restaurant.command.domain.SocialMedia.INSTAGRAM;
+import static com.celuveat.restaurant.command.domain.SocialMedia.YOUTUBE;
+
 import com.celuveat.celeb.command.domain.Celeb;
 import com.celuveat.restaurant.command.domain.Restaurant;
 import com.celuveat.restaurant.command.domain.RestaurantImage;
@@ -74,7 +77,7 @@ public record SaveDataRequest(
             String instagramName,
             Restaurant restaurant
     ) {
-        SocialMedia socialMedia = SocialMedia.from(instagramName);
+        SocialMedia socialMedia = toSocialMedia(instagramName);
         String author = switch (socialMedia) {
             case INSTAGRAM -> instagramName;
             default -> youtubeChannelName;
@@ -86,6 +89,13 @@ public record SaveDataRequest(
                 .socialMedia(socialMedia)
                 .restaurant(restaurant)
                 .build();
+    }
+
+    private SocialMedia toSocialMedia(String instagramName) {
+        if (instagramName.strip().isBlank()) {
+            return YOUTUBE;
+        }
+        return INSTAGRAM;
     }
 
     public Video toVideo(String youtubeVideoUrl, LocalDate uploadDate, Celeb celeb, Restaurant restaurant) {

--- a/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveImageRequest.java
+++ b/backend/src/main/java/com/celuveat/admin/presentation/dto/SaveImageRequest.java
@@ -1,0 +1,17 @@
+package com.celuveat.admin.presentation.dto;
+
+import com.celuveat.admin.command.application.dto.SaveImageCommand;
+import org.springframework.web.multipart.MultipartFile;
+
+public record SaveImageRequest(
+        Long restaurantId,
+        String author,
+        String name,
+        String socialMedia,
+        MultipartFile image
+) {
+
+    public SaveImageCommand toCommand() {
+        return new SaveImageCommand(restaurantId, author, name, socialMedia);
+    }
+}

--- a/backend/src/main/java/com/celuveat/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/celuveat/auth/config/AuthConfig.java
@@ -27,6 +27,7 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(setUpAuthInterceptor())
                 .addPathPatterns(
                         "/restaurants/**/like",
+                        "/restaurants/images",
                         "/reviews/**",
                         "/members/**",
                         "/oauth/logout/**",

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionService.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionService.java
@@ -1,0 +1,31 @@
+package com.celuveat.restaurant.command.application;
+
+import com.celuveat.auth.command.domain.OauthMember;
+import com.celuveat.auth.command.domain.OauthMemberRepository;
+import com.celuveat.restaurant.command.application.dto.SuggestImagesCommand;
+import com.celuveat.restaurant.command.domain.Restaurant;
+import com.celuveat.restaurant.command.domain.RestaurantImageSuggestion;
+import com.celuveat.restaurant.command.domain.RestaurantImageSuggestionRepository;
+import com.celuveat.restaurant.command.domain.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RestaurantImageSuggestionService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final OauthMemberRepository oauthMemberRepository;
+    private final RestaurantImageSuggestionRepository restaurantImageSuggestionRepository;
+
+    public void suggestImages(SuggestImagesCommand command) {
+        Restaurant restaurant = restaurantRepository.getById(command.restaurantId());
+        OauthMember member = oauthMemberRepository.getById(command.memberId());
+        restaurantImageSuggestionRepository.saveAll(command.imageNames().stream()
+                .map(imageName -> new RestaurantImageSuggestion(imageName, member, restaurant))
+                .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/command/application/dto/SuggestImagesCommand.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/application/dto/SuggestImagesCommand.java
@@ -1,0 +1,10 @@
+package com.celuveat.restaurant.command.application.dto;
+
+import java.util.List;
+
+public record SuggestImagesCommand(
+        Long restaurantId,
+        Long memberId,
+        List<String> imageNames
+) {
+}

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestion.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestion.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class RestaurantImageSuggestion extends BaseEntity {
 
     @Column(nullable = false)
-    private String name;
+    private String imageName;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
@@ -28,8 +28,8 @@ public class RestaurantImageSuggestion extends BaseEntity {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
-    public String name() {
-        return name;
+    public String imageName() {
+        return imageName;
     }
 
     public OauthMember member() {

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestion.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestion.java
@@ -1,0 +1,42 @@
+package com.celuveat.restaurant.command.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.celuveat.auth.command.domain.OauthMember;
+import com.celuveat.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class RestaurantImageSuggestion extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private OauthMember member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    public String name() {
+        return name;
+    }
+
+    public OauthMember member() {
+        return member;
+    }
+
+    public Restaurant restaurant() {
+        return restaurant;
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestionRepository.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/RestaurantImageSuggestionRepository.java
@@ -1,0 +1,10 @@
+package com.celuveat.restaurant.command.domain;
+
+import com.celuveat.auth.command.domain.OauthMember;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantImageSuggestionRepository extends JpaRepository<RestaurantImageSuggestion, Long> {
+
+    List<RestaurantImageSuggestion> findAllByMember(OauthMember member);
+}

--- a/backend/src/main/java/com/celuveat/restaurant/command/domain/SocialMedia.java
+++ b/backend/src/main/java/com/celuveat/restaurant/command/domain/SocialMedia.java
@@ -1,15 +1,27 @@
 package com.celuveat.restaurant.command.domain;
 
+import static com.celuveat.restaurant.exception.RestaurantImageExceptionType.UNSUPPORTED_SOCIAL_MEDIA;
+
+import com.celuveat.restaurant.exception.RestaurantImageException;
+import java.util.Arrays;
+
 public enum SocialMedia {
 
-    YOUTUBE,
-    INSTAGRAM,
+    YOUTUBE("youtube"),
+    INSTAGRAM("instagram"),
     ;
 
-    public static SocialMedia from(String instagramName) {
-        if (instagramName.strip().isBlank()) {
-            return YOUTUBE;
-        }
-        return INSTAGRAM;
+    private final String value;
+
+    SocialMedia(String value) {
+        this.value = value;
+    }
+
+    public static SocialMedia from(String value) {
+        String socialMedia = value.strip().toLowerCase();
+        return Arrays.stream(values())
+                .filter(it -> it.value.equals(socialMedia))
+                .findAny()
+                .orElseThrow(() -> new RestaurantImageException(UNSUPPORTED_SOCIAL_MEDIA));
     }
 }

--- a/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageException.java
+++ b/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageException.java
@@ -1,0 +1,16 @@
+package com.celuveat.restaurant.exception;
+
+import com.celuveat.common.exception.BaseException;
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RestaurantImageException extends BaseException {
+
+    private final RestaurantImageExceptionType exceptionType;
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageExceptionType.java
+++ b/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageExceptionType.java
@@ -1,0 +1,27 @@
+package com.celuveat.restaurant.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum RestaurantImageExceptionType implements BaseExceptionType {
+
+    UNSUPPORTED_SOCIAL_MEDIA(BAD_REQUEST, "지원하지 않는 소셜 미디어입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageSuggestionException.java
+++ b/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageSuggestionException.java
@@ -1,0 +1,16 @@
+package com.celuveat.restaurant.exception;
+
+import com.celuveat.common.exception.BaseException;
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RestaurantImageSuggestionException extends BaseException {
+
+    private final RestaurantImageSuggestionExceptionType exceptionType;
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageSuggestionExceptionType.java
+++ b/backend/src/main/java/com/celuveat/restaurant/exception/RestaurantImageSuggestionExceptionType.java
@@ -1,0 +1,27 @@
+package com.celuveat.restaurant.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.celuveat.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum RestaurantImageSuggestionExceptionType implements BaseExceptionType {
+
+    IMAGES_CAN_NOT_BE_NULL(BAD_REQUEST, "이미지는 널일 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/RestaurantController.java
@@ -5,12 +5,15 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.celuveat.common.PageResponse;
 import com.celuveat.common.auth.Auth;
 import com.celuveat.common.auth.LooseAuth;
+import com.celuveat.common.client.ImageUploadClient;
 import com.celuveat.restaurant.command.application.RestaurantCorrectionService;
+import com.celuveat.restaurant.command.application.RestaurantImageSuggestionService;
 import com.celuveat.restaurant.command.application.RestaurantLikeService;
 import com.celuveat.restaurant.command.application.RestaurantService;
 import com.celuveat.restaurant.presentation.dto.LocationSearchCondRequest;
 import com.celuveat.restaurant.presentation.dto.RestaurantSearchCondRequest;
 import com.celuveat.restaurant.presentation.dto.SuggestCorrectionRequest;
+import com.celuveat.restaurant.presentation.dto.SuggestImagesRequest;
 import com.celuveat.restaurant.query.RestaurantQueryService;
 import com.celuveat.restaurant.query.dao.RestaurantSearchQueryResponseDao.LocationSearchCond;
 import com.celuveat.restaurant.query.dao.RestaurantSearchQueryResponseDao.RestaurantSearchCond;
@@ -39,10 +42,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/restaurants")
 public class RestaurantController {
 
+    private final ImageUploadClient imageUploadClient;
     private final RestaurantService restaurantService;
     private final RestaurantLikeService restaurantLikeService;
     private final RestaurantQueryService restaurantQueryService;
     private final RestaurantCorrectionService restaurantCorrectionService;
+    private final RestaurantImageSuggestionService restaurantImageSuggestionService;
 
     @GetMapping("/{restaurantId}")
     ResponseEntity<RestaurantDetailQueryResponse> findById(
@@ -101,6 +106,13 @@ public class RestaurantController {
     ResponseEntity<List<LikedRestaurantQueryResponse>> findLikedByMember(@Auth Long memberId) {
         List<LikedRestaurantQueryResponse> result = restaurantQueryService.findLikedByMemberId(memberId);
         return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/images")
+    ResponseEntity<Void> suggestImages(@ModelAttribute SuggestImagesRequest request, @Auth Long memberId) {
+        imageUploadClient.upload(request.images());
+        restaurantImageSuggestionService.suggestImages(request.toCommand(memberId));
+        return ResponseEntity.status(CREATED).build();
     }
 
     @PostMapping("/{restaurantId}/correction")

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/dto/SuggestImagesRequest.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/dto/SuggestImagesRequest.java
@@ -1,0 +1,22 @@
+package com.celuveat.restaurant.presentation.dto;
+
+import com.celuveat.common.util.FileNameUtil;
+import com.celuveat.restaurant.command.application.dto.SuggestImagesCommand;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.web.multipart.MultipartFile;
+
+public record SuggestImagesRequest(
+        Long restaurantId,
+        List<MultipartFile> images
+) {
+
+    public SuggestImagesCommand toCommand(Long memberId) {
+        List<String> imageNames = images.stream()
+                .map(MultipartFile::getOriginalFilename)
+                .filter(Objects::nonNull)
+                .map(FileNameUtil::removeExtension)
+                .toList();
+        return new SuggestImagesCommand(restaurantId, memberId, imageNames);
+    }
+}

--- a/backend/src/main/java/com/celuveat/restaurant/presentation/dto/SuggestImagesRequest.java
+++ b/backend/src/main/java/com/celuveat/restaurant/presentation/dto/SuggestImagesRequest.java
@@ -1,7 +1,10 @@
 package com.celuveat.restaurant.presentation.dto;
 
+import static com.celuveat.restaurant.exception.RestaurantImageSuggestionExceptionType.IMAGES_CAN_NOT_BE_NULL;
+
 import com.celuveat.common.util.FileNameUtil;
 import com.celuveat.restaurant.command.application.dto.SuggestImagesCommand;
+import com.celuveat.restaurant.exception.RestaurantImageSuggestionException;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,6 +15,9 @@ public record SuggestImagesRequest(
 ) {
 
     public SuggestImagesCommand toCommand(Long memberId) {
+        if (Objects.isNull(images)) {
+            throw new RestaurantImageSuggestionException(IMAGES_CAN_NOT_BE_NULL);
+        }
         List<String> imageNames = images.stream()
                 .map(MultipartFile::getOriginalFilename)
                 .filter(Objects::nonNull)

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceSteps.java
@@ -128,7 +128,7 @@ public class AdminAcceptanceSteps {
         requestSpecification.multiPart(멀티파트_스팩을_추출한다("image", 요청.image()));
         return requestSpecification
                 .contentType("multipart/form-data")
-                .when().post("/admin/images")
+                .when().post("/admin/restaurant-images")
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
@@ -4,10 +4,17 @@ import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_입�
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.데이터_저장_요청;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_입력_생성;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.셀럽_저장_요청;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.음식점_이미지_저장_요청;
+import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.음식점_이미지_저장_요청_데이터;
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.줄바꿈;
+import static com.celuveat.acceptance.common.AcceptanceSteps.생성됨;
+import static com.celuveat.acceptance.common.AcceptanceSteps.응답_상태를_검증한다;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
+import static com.celuveat.restaurant.fixture.RestaurantFixture.대성집;
 
 import com.celuveat.acceptance.common.AcceptanceTest;
+import com.celuveat.restaurant.command.domain.Restaurant;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -81,6 +88,30 @@ class AdminAcceptanceTest extends AcceptanceTest {
 
             // then
             데이터_수_검증(4, celebRepository);
+        }
+    }
+
+    @Nested
+    class 이미지를_저장한다 {
+
+        private final Restaurant 대성집 = 대성집();
+
+        @BeforeEach
+        void setUp() {
+            testData.addRestaurants(대성집);
+            초기_데이터_저장();
+        }
+
+        @Test
+        void 음식점_이미지를_저장한다() {
+            // given
+            var 음식점_이미지 = 음식점_이미지_저장_요청_데이터(대성집.id(), "오도", "instagram", "imageA");
+
+            // when
+            var 응답 = 음식점_이미지_저장_요청(음식점_이미지);
+
+            // then
+            응답_상태를_검증한다(응답, 생성됨);
         }
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/admin/AdminAcceptanceTest.java
@@ -9,6 +9,7 @@ import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.음식점_이�
 import static com.celuveat.acceptance.admin.AdminAcceptanceSteps.줄바꿈;
 import static com.celuveat.acceptance.common.AcceptanceSteps.생성됨;
 import static com.celuveat.acceptance.common.AcceptanceSteps.응답_상태를_검증한다;
+import static com.celuveat.acceptance.common.AcceptanceSteps.찾을수_없음;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.대성집;
 
@@ -103,7 +104,7 @@ class AdminAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 음식점_이미지를_저장한다() {
+        void 이미_저장되어_있는_음식점의_이미지를_추가한다() {
             // given
             var 음식점_이미지 = 음식점_이미지_저장_요청_데이터(대성집.id(), "오도", "instagram", "imageA");
 
@@ -112,6 +113,18 @@ class AdminAcceptanceTest extends AcceptanceTest {
 
             // then
             응답_상태를_검증한다(응답, 생성됨);
+        }
+
+        @Test
+        void 존재하지_않는_음식점_이미지를_저장하려하면_예외가_발생한다() {
+            // given
+            var 음식점_이미지 = 음식점_이미지_저장_요청_데이터(100L, "오도", "instagram", "imageA");
+
+            // when
+            var 응답 = 음식점_이미지_저장_요청(음식점_이미지);
+
+            // then
+            응답_상태를_검증한다(응답, 찾을수_없음);
         }
     }
 }

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceSteps.java
@@ -125,7 +125,7 @@ public class RestaurantAcceptanceSteps {
                 .build();
         RequestSpecification requestSpecification = given(세션_아이디)
                 .multiPart(restaurantId);
-        요청.images().forEach(image -> requestSpecification.multiPart(멀티파트_스팩을_추출한다(image)));
+        요청.images().forEach(image -> requestSpecification.multiPart(멀티파트_스팩을_추출한다("images", image)));
         return requestSpecification
                 .contentType("multipart/form-data")
                 .when().post("/restaurants/images")
@@ -133,10 +133,10 @@ public class RestaurantAcceptanceSteps {
                 .extract();
     }
 
-    public static MultiPartSpecification 멀티파트_스팩을_추출한다(MultipartFile image) {
+    public static MultiPartSpecification 멀티파트_스팩을_추출한다(String 컨트롤네임, MultipartFile image) {
         try {
             return new MultiPartSpecBuilder(image.getBytes())
-                    .controlName("images")
+                    .controlName(컨트롤네임)
                     .fileName(image.getName())
                     .charset(UTF_8)
                     .build();

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantAcceptanceTest.java
@@ -13,6 +13,8 @@ import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음�
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_검색_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_검색_조건_요청_데이터;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_상세_조회_요청;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_이미지_제안_요청;
+import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_이미지_제안_요청_데이터;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_좋아요_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.음식점_좋아요_정렬_검색_요청;
 import static com.celuveat.acceptance.restaurant.RestaurantAcceptanceSteps.정보_수정_제안_요청;
@@ -281,6 +283,34 @@ public class RestaurantAcceptanceTest extends AcceptanceTest {
 
                 // then
                 응답_상태를_검증한다(응답, 잘못된_요청);
+            }
+        }
+
+        @Nested
+        class 음식점_제안_API {
+
+            private final OauthMember 말랑 = 말랑();
+            private final Restaurant 대성집 = 대성집();
+
+            @BeforeEach
+            void setUp() {
+                testData.addMembers(말랑);
+                testData.addRestaurants(대성집);
+                초기_데이터_저장();
+            }
+
+            @Test
+            void 음식점_이미지를_제안한다() {
+                // given
+                var 말랑_세션_아이디 = 로그인후_세션아이디를_가져온다(말랑);
+                var 말랑_이미지_제안 = 음식점_이미지_제안_요청_데이터(대성집.id(),
+                        List.of("mallang review image 1", "mallang review image2"));
+
+                // when
+                var 응답 = 음식점_이미지_제안_요청(말랑_세션_아이디, 말랑_이미지_제안);
+
+                // then
+                응답_상태를_검증한다(응답, 생성됨);
             }
         }
 

--- a/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
+++ b/backend/src/test/java/com/celuveat/acceptance/restaurant/RestaurantReviewAcceptanceSteps.java
@@ -50,7 +50,7 @@ public class RestaurantReviewAcceptanceSteps {
                 .multiPart(content)
                 .multiPart(restaurantId)
                 .multiPart(rating);
-        요청.images().forEach(image -> requestSpecification.multiPart(멀티파트_스팩을_추출한다(image)));
+        요청.images().forEach(image -> requestSpecification.multiPart(멀티파트_스팩을_추출한다("images", image)));
         return requestSpecification
                 .contentType("multipart/form-data")
                 .when().post("/reviews")

--- a/backend/src/test/java/com/celuveat/admin/command/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/celuveat/admin/command/application/AdminServiceTest.java
@@ -14,12 +14,14 @@ import static com.celuveat.celeb.exception.CelebExceptionType.NOT_FOUND_CELEB;
 import static com.celuveat.celeb.fixture.CelebFixture.셀럽;
 import static com.celuveat.restaurant.command.domain.SocialMedia.INSTAGRAM;
 import static com.celuveat.restaurant.command.domain.SocialMedia.YOUTUBE;
+import static com.celuveat.restaurant.fixture.RestaurantFixture.대성집;
 import static com.celuveat.restaurant.fixture.RestaurantFixture.하늘초밥;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.celuveat.acceptance.admin.AdminAcceptanceSteps;
+import com.celuveat.admin.command.application.dto.SaveImageCommand;
 import com.celuveat.admin.exception.AdminException;
 import com.celuveat.admin.presentation.dto.SaveCelebRequest;
 import com.celuveat.admin.presentation.dto.SaveDataRequest;
@@ -27,8 +29,12 @@ import com.celuveat.celeb.command.domain.Celeb;
 import com.celuveat.celeb.exception.CelebException;
 import com.celuveat.common.IntegrationTest;
 import com.celuveat.common.exception.BaseExceptionType;
+import com.celuveat.restaurant.command.domain.Restaurant;
 import com.celuveat.restaurant.command.domain.RestaurantImage;
+import com.celuveat.restaurant.command.domain.SocialMedia;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -306,6 +312,34 @@ class AdminServiceTest extends IntegrationTest {
             BaseExceptionType exceptionType = assertThrows(AdminException.class,
                     () -> 셀럽_저장_요청_생성(입력_데이터)).exceptionType();
             assertThat(exceptionType).isEqualTo(INVALID_URL_PATTERN);
+        }
+    }
+
+    @Nested
+    class 이미지_저장 {
+
+        private Restaurant 대성집;
+
+        @BeforeEach
+        void setUp() {
+            대성집 = restaurantRepository.save(대성집());
+        }
+
+        @Test
+        void 음식점_이미지를_저장한다() {
+            // given
+            SaveImageCommand saveImageCommand = new SaveImageCommand(대성집.id(), "오도", "imageA", "instagram");
+            RestaurantImage expected = new RestaurantImage("imageA", "오도", SocialMedia.INSTAGRAM, 대성집);
+
+            // when
+            Long imageId = adminService.saveImage(saveImageCommand);
+            Optional<RestaurantImage> result = restaurantImageRepository.findById(imageId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
         }
     }
 }

--- a/backend/src/test/java/com/celuveat/common/IntegrationTest.java
+++ b/backend/src/test/java/com/celuveat/common/IntegrationTest.java
@@ -6,12 +6,14 @@ import com.celuveat.auth.command.domain.authcode.AuthCodeRequestUrlProviderCompo
 import com.celuveat.celeb.command.domain.CelebRepository;
 import com.celuveat.common.client.ImageUploadClient;
 import com.celuveat.restaurant.command.application.RestaurantCorrectionService;
+import com.celuveat.restaurant.command.application.RestaurantImageSuggestionService;
 import com.celuveat.restaurant.command.application.RestaurantLikeService;
 import com.celuveat.restaurant.command.application.RestaurantReviewLikeService;
 import com.celuveat.restaurant.command.application.RestaurantReviewReportService;
 import com.celuveat.restaurant.command.application.RestaurantReviewService;
 import com.celuveat.restaurant.command.application.RestaurantService;
 import com.celuveat.restaurant.command.domain.RestaurantImageRepository;
+import com.celuveat.restaurant.command.domain.RestaurantImageSuggestionRepository;
 import com.celuveat.restaurant.command.domain.RestaurantLikeRepository;
 import com.celuveat.restaurant.command.domain.RestaurantRepository;
 import com.celuveat.restaurant.command.domain.correction.RestaurantCorrectionRepository;
@@ -62,6 +64,9 @@ public abstract class IntegrationTest {
     protected RestaurantReviewRepository restaurantReviewRepository;
 
     @Autowired
+    protected RestaurantImageSuggestionRepository restaurantImageSuggestionRepository;
+
+    @Autowired
     protected AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
 
     @Autowired
@@ -90,6 +95,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected RestaurantReviewReportService restaurantReviewReportService;
+
+    @Autowired
+    protected RestaurantImageSuggestionService restaurantImageSuggestionService;
 
     @Autowired
     protected RestaurantReviewService restaurantReviewService;

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionServiceTest.java
@@ -1,0 +1,44 @@
+package com.celuveat.restaurant.command.application;
+
+import static com.celuveat.auth.fixture.OauthMemberFixture.말랑;
+import static com.celuveat.restaurant.fixture.RestaurantFixture.대성집;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.celuveat.auth.command.domain.OauthMember;
+import com.celuveat.common.IntegrationTest;
+import com.celuveat.restaurant.command.application.dto.SuggestImagesCommand;
+import com.celuveat.restaurant.command.domain.Restaurant;
+import com.celuveat.restaurant.command.domain.RestaurantImageSuggestion;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("음식점 이미지 제안 서비스(RestaurantImageSuggestionService) 은(는)")
+class RestaurantImageSuggestionServiceTest extends IntegrationTest {
+
+    private Restaurant 대성집;
+    private OauthMember 말랑;
+
+    @BeforeEach
+    void setUp() {
+        대성집 = restaurantRepository.save(대성집());
+        말랑 = oauthMemberRepository.save(말랑());
+    }
+
+    @Test
+    void 사용자가_사진들을_제안한다() {
+        // given
+        List<String> imageNames = List.of("imageA", "imageB");
+        SuggestImagesCommand command = new SuggestImagesCommand(대성집.id(), 말랑.id(), imageNames);
+
+        // when
+        restaurantImageSuggestionService.suggestImages(command);
+        List<RestaurantImageSuggestion> imageSuggestions = restaurantImageSuggestionRepository.findAllByMember(말랑);
+
+        // then
+        assertThat(imageSuggestions).hasSize(2);
+        assertThat(imageSuggestions).extracting("name")
+                .containsExactlyInAnyOrder("imageA", "imageB");
+    }
+}

--- a/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionServiceTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/application/RestaurantImageSuggestionServiceTest.java
@@ -38,7 +38,7 @@ class RestaurantImageSuggestionServiceTest extends IntegrationTest {
 
         // then
         assertThat(imageSuggestions).hasSize(2);
-        assertThat(imageSuggestions).extracting("name")
+        assertThat(imageSuggestions).extracting("imageName")
                 .containsExactlyInAnyOrder("imageA", "imageB");
     }
 }

--- a/backend/src/test/java/com/celuveat/restaurant/command/domain/SocialMediaTest.java
+++ b/backend/src/test/java/com/celuveat/restaurant/command/domain/SocialMediaTest.java
@@ -1,0 +1,47 @@
+package com.celuveat.restaurant.command.domain;
+
+import static com.celuveat.restaurant.exception.RestaurantImageExceptionType.UNSUPPORTED_SOCIAL_MEDIA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.celuveat.common.exception.BaseException;
+import com.celuveat.common.exception.BaseExceptionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("소셜미디어(SocialMedia) 은(는)")
+class SocialMediaTest {
+
+    @ParameterizedTest
+    @CsvSource({"Youtube", "youtube", "YOUTUBE", "YouTube", " Youtube", "youtube ", " YOUTUBE "})
+    void youtube를_변환한다(String value) {
+        // when
+        SocialMedia socialMedia = SocialMedia.from(value);
+
+        // then
+        assertThat(socialMedia).isEqualTo(SocialMedia.YOUTUBE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"Instagram", "instagram", "INSTAGRAM", " Instagram", "instagram ", " INSTAGRAM "})
+    void instagram을_변환한다(String value) {
+        // when
+        SocialMedia socialMedia = SocialMedia.from(value);
+
+        // then
+        assertThat(socialMedia).isEqualTo(SocialMedia.INSTAGRAM);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"kakao", "naver"})
+    void 존재하지_않는_타입은_예외를_발생시킨다(String value) {
+        // when
+        BaseExceptionType result = assertThrows(BaseException.class, () ->
+                SocialMedia.from(value)
+        ).exceptionType();
+
+        // then
+        assertThat(result).isEqualTo(UNSUPPORTED_SOCIAL_MEDIA);
+    }
+}


### PR DESCRIPTION
## ✨ 요약
- 음식점 사진 추가 API 구현
- 사용자가 사진 추가 제안하는 API 구현
```
CREATE TABLE `restaurant_image_suggestion`
(
    `id`            bigint       NOT NULL AUTO_INCREMENT,
    `restaurant_id` bigint            DEFAULT NULL,
    `member_id`     bigint            DEFAULT NULL,
    `image_name` varchar(255) NOT NULL,
    `created_date`  timestamp(6) NULL DEFAULT NULL,
    PRIMARY KEY (`id`),
    KEY `fk_restaurant_image_suggestion_restaurant_id_from_restaurant_id` (`restaurant_id`),
    KEY `fk_restaurant_image_suggestion_member_id_from_oauth_member_id` (`member_id`),
    CONSTRAINT `fk_restaurant_image_suggestion_member_id_from_oauth_member_id` FOREIGN KEY (`member_id`) REFERENCES `oauth_member` (`id`),
    CONSTRAINT `fk_restaurant_image_suggestion_restaurant_id_from_restaurant_id` FOREIGN KEY (`restaurant_id`) REFERENCES `restaurant` (`id`)
) ENGINE = InnoDB
  AUTO_INCREMENT = 10
  DEFAULT CHARSET = utf8mb4
  COLLATE = utf8mb4_0900_ai_ci;
```

<br><br>

## 😎 해결한 이슈
- close #530 

<br><br>
