### PR TITLE
fix: 사진없이 데이터 저장시 음식점 이미지가 공백으로 저장되는 버그 수정

### DIFF
--- a/backend/src/main/java/com/celuveat/admin/command/application/AdminService.java
+++ b/backend/src/main/java/com/celuveat/admin/command/application/AdminService.java
@@ -4,6 +4,7 @@ import static com.celuveat.admin.exception.AdminExceptionType.ALREADY_EXISTS_RES
 import static com.celuveat.admin.exception.AdminExceptionType.ILLEGAL_DATE_FORMAT;
 import static com.celuveat.admin.exception.AdminExceptionType.MISMATCH_COUNT_IMAGE_NAME_AND_INSTAGRAM_NAME;
 import static com.celuveat.admin.exception.AdminExceptionType.MISMATCH_COUNT_YOUTUBE_VIDEO_LINK_AND_UPLOAD_DATE;
+import static java.util.Collections.emptyList;
 
 import com.celuveat.admin.exception.AdminException;
 import com.celuveat.admin.presentation.dto.SaveCelebRequest;
@@ -49,7 +50,8 @@ public class AdminService {
     }
 
     private void validateDuplicate(SaveDataRequest request) {
-        Optional<Restaurant> restaurant = restaurantRepository.findByNameAndRoadAddress(request.restaurantName(), request.roadAddress());
+        Optional<Restaurant> restaurant =
+                restaurantRepository.findByNameAndRoadAddress(request.restaurantName(), request.roadAddress());
         boolean existVideo = videoRepository.existsByYoutubeUrl(request.youtubeVideoUrl());
 
         if (restaurant.isPresent() && existVideo) {
@@ -65,6 +67,10 @@ public class AdminService {
     }
 
     private List<RestaurantImage> toRestaurantImages(SaveDataRequest request, Restaurant restaurant) {
+        if (request.imageName().isBlank()) {
+            return emptyList();
+        }
+
         String[] imageNames = request.imageName().split(",");
         String[] instagramNames = request.instagramName().split(",");
         if (imageNames.length != instagramNames.length) {

--- a/backend/src/main/java/com/celuveat/celeb/exception/CelebExceptionType.java
+++ b/backend/src/main/java/com/celuveat/celeb/exception/CelebExceptionType.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CelebExceptionType implements BaseExceptionType {
 
-    NOT_FOUND_CELEB(BAD_REQUEST, "음식점을 찾을 수 없습니다"),
+    NOT_FOUND_CELEB(BAD_REQUEST, "셀럽이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/test/java/com/celuveat/admin/command/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/celuveat/admin/command/application/AdminServiceTest.java
@@ -294,6 +294,32 @@ class AdminServiceTest extends IntegrationTest {
             // then
             assertThat(exceptionType).isEqualTo(ALREADY_EXISTS_RESTAURANT_AND_VIDEO);
         }
+
+        @Test
+        void 음식점_사진이_없으면_사진을_제외하고_저장한다() {
+            // given
+            celebRepository.save(성시경());
+            String rawData = "하늘초밥" +
+                    "\thttps://www.youtube.com/watch?v=GeZRxKUCFtM" +
+                    "\t@sungsikyung" +
+                    "\t2021. 9. 21." +
+                    "\thttps://map.naver.com/v5/entry/place/1960457705?entry=plt&c=15,0,0,0,dh" +
+                    "\t초밥,롤" +
+                    "\t0507-1366-4573" +
+                    "\t서울 서대문구 이화여대2길 14 1층 하늘초밥" +
+                    "\t37.5572713" +
+                    "\t126.9466788" +
+                    "\t" +
+                    "\t";
+            List<SaveDataRequest> 요청 = 데이터저장_요청_객체_생성(rawData);
+
+            // when
+            adminService.saveData(요청);
+
+            // then
+            List<RestaurantImage> restaurantImages = restaurantImageRepository.findAll();
+            assertThat(restaurantImages.size()).isZero();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## ✨ 요약
1. 사진없이 데이터 저장할 때 음식점 이미지 데이터가 공백으로 저장되는 현상을 아예 저장되지 않도록 수정했습니다.

<br>

## 😎 해결한 이슈
- close #633 

<br>