### PR TITLE
hotfix: 상세페이지에서 주변다른식당으로 이동시 뒤로가기 기능이 동작하지 않는 오류 개선

### DIFF
--- a/frontend/src/components/MiniRestaurantCard/MiniRestaurantCard.tsx
+++ b/frontend/src/components/MiniRestaurantCard/MiniRestaurantCard.tsx
@@ -1,6 +1,5 @@
 import { css, styled } from 'styled-components';
 import { MouseEventHandler, memo, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Love from '~/assets/icons/love.svg';
 import { FONT_SIZE, truncateText } from '~/styles/common';
 import Star from '~/assets/icons/star.svg';
@@ -37,9 +36,12 @@ function MiniRestaurantCard({
 }: MiniRestaurantCardProps) {
   const { id, images, name, roadAddress, category, rating, distance } = restaurant;
   const { toggleRestaurantLike, isLiked } = useToggleLikeNotUpdate(restaurant);
-  const navigate = useNavigate();
 
-  const register = useOnClickBlock({ callback: () => navigate(`/restaurants/${id}?celebId=${celebs[0].id}`) });
+  const register = useOnClickBlock({
+    callback: () => {
+      window.location.href = `/restaurants/${id}?celebId=${celebs[0].id}`;
+    },
+  });
 
   const handleCardMouseEnter = useCallback(() => {
     setHoveredId(restaurant.id);


### PR DESCRIPTION
## ✨ 요약
```
useNavigate에서 window.location.href로 대치함으로써 문제를 해결하였습니다.
물론 이렇게 된다면 새로고침이 발생하면서 리액트쿼리의 캐싱기능이 무효화됩니다.
하지만 캐싱에 앞서 정상적으로 동작하는 것이 우선이기에 
추후 더 나은 해결방안이 나온다면 개선해보겠습니다.
```

<br><br>


https://github.com/woowacourse-teams/2023-celuveat/assets/102432453/fff8fc84-3238-4c03-8b34-157be9f8e307



## 😎 해결한 이슈
- close #688

<br><br>
