### PR TITLE
refactor: E2E 테스트 코드 개선 및 추가 작성

### DIFF
--- a/frontend/cypress/e2e/desktop/like.cy.ts
+++ b/frontend/cypress/e2e/desktop/like.cy.ts
@@ -23,4 +23,16 @@ describe('좋아요 관련 기능을 테스트 한다.', () => {
 
     cy.get('ul').should('not.contain.text', targetName);
   });
+
+  it('좋아요를 누른 음식점을 위시리스트에서 좋아요를 해제해도 바로 제거되지 않는다. 즉 새로고침을 해야 제거된다.', () => {
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').contains('위시리스트').click();
+
+    cy.getByAriaLabel(`${targetName} 카드`).find('[aria-label="좋아요"]').click();
+    cy.get('ul').should('contain.text', targetName);
+
+    cy.reload();
+
+    cy.get('ul').should('not.contain.text', targetName);
+  });
 });

--- a/frontend/cypress/e2e/desktop/like.cy.ts
+++ b/frontend/cypress/e2e/desktop/like.cy.ts
@@ -1,19 +1,18 @@
 describe('좋아요 관련 기능을 테스트 한다.', () => {
+  const targetName = '소문난성수감자탕';
+
   beforeEach(() => {
-    cy.visit('/restaurants/311?celebId=7');
+    cy.visit('');
+
+    cy.loginGoogleForDesktop();
+    cy.getByAriaLabel(`${targetName} 카드`).first().click();
+    cy.contains('위시리스트').click();
   });
 
-  it('성시경 소문난성수감자탕 페이지에서 좋아요를 한 후 위시리스트에 잘 담겨 있는지 확인한다.', () => {
-    // 로그인이 되지 않은 상태에서 위시리스트 저장하기를 누른다.
-    // cy.contains('위시리스트에 저장하기').click();
-    // cy.contains('구글로 로그인하기').click();
-    // // cy.loginGoogleForDesktop();
-    // // 위시리스트 버튼을 다시 누른다.
-    // cy.contains('위시리스트에 저장하기').click();
-    // cy.get('button[aria-label="로그인"]').click(); // 프로필 아이콘을 누른다.
-    // cy.get('li[data-name="위시리스트"]').click(); // 위시리스트 버튼을 누른다.
-    // // 좋아요를 취소한다.
-    // cy.get('li[aria-label="소문난성수감자탕 카드"]').find('button').click();
-    // cy.shouldIsLiked('소문난성수감자탕 카드', false);
+  it('좋아요를 누른 음식점은 위시리스트에 저장된다.', () => {
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').contains('위시리스트').click();
+
+    cy.get('ul').should('contain.text', targetName);
   });
 });

--- a/frontend/cypress/e2e/desktop/like.cy.ts
+++ b/frontend/cypress/e2e/desktop/like.cy.ts
@@ -15,4 +15,12 @@ describe('좋아요 관련 기능을 테스트 한다.', () => {
 
     cy.get('ul').should('contain.text', targetName);
   });
+
+  it('좋아요를 취소하면 위시리스트에서 제거된다.', () => {
+    cy.contains('위시리스트').click();
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').contains('위시리스트').click();
+
+    cy.get('ul').should('not.contain.text', targetName);
+  });
 });

--- a/frontend/cypress/e2e/desktop/login.cy.ts
+++ b/frontend/cypress/e2e/desktop/login.cy.ts
@@ -1,13 +1,28 @@
 describe('로그인 관련 로직을 테스트 한다.', () => {
-  it('사용자가 구글 로그인을 하면 비회원 상태이던 프로필 이미지가 구글 로그인 프로필 이미지로 변경된다.', () => {
-    cy.visit('/restaurants/311?celebId=7');
+  it('로그인 - 새로고침 - 로그아웃 테스트', () => {
+    cy.visit('');
 
-    cy.getByAriaLabel('프로필').click(); // 프로필 아이콘을 누른다.
-    cy.getByAriaLabel('로그인').click(); // 로그인 버튼을 누른다.
-    cy.contains('구글로 로그인하기').click(); // 로그인 버튼을 누른다.
+    cy.getByAriaLabel('프로필').click();
+    /** 로그인 전에는 마이 페이지 탭이 존재하지 않는다. */
+    cy.getByCy('dropdown').should('not.contain.text', '마이 페이지');
+    cy.getByAriaLabel('로그인').click();
+    cy.contains('구글로 로그인하기').click();
 
-    // cy.loginGoogleForDesktop();
+    /** 로그인에 성공했다면 마이 페이지 탭이 존재한다. */
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').should('contain.text', '마이 페이지');
 
-    // cy.get('button[aria-label="로그인"]').find('img').should('have.attr', 'alt', '푸만능 프로필');
+    /** 새로고침을 하더라도 로그인 상태는 유지된다. */
+    cy.reload();
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').should('contain.text', '마이 페이지');
+
+    /** 로그아웃 이후 프로필 클릭시 로그인 탭만 존재한다. */
+    cy.getByCy('dropdown').contains('마이 페이지').click();
+    cy.contains('로그아웃').click();
+    cy.wait(1000);
+    cy.getByAriaLabel('프로필').click();
+    cy.getByCy('dropdown').should('contain.text', '로그인');
+    cy.getByCy('dropdown').should('not.contain.text', '마이 페이지');
   });
 });

--- a/frontend/cypress/e2e/desktop/login.cy.ts
+++ b/frontend/cypress/e2e/desktop/login.cy.ts
@@ -2,8 +2,8 @@ describe('로그인 관련 로직을 테스트 한다.', () => {
   it('사용자가 구글 로그인을 하면 비회원 상태이던 프로필 이미지가 구글 로그인 프로필 이미지로 변경된다.', () => {
     cy.visit('/restaurants/311?celebId=7');
 
-    cy.get('button[aria-label="로그인"]').click(); // 프로필 아이콘을 누른다.
-    cy.get('li[data-name="로그인"]').click(); // 로그인 버튼을 누른다.
+    cy.getByAriaLabel('프로필').click(); // 프로필 아이콘을 누른다.
+    cy.getByAriaLabel('로그인').click(); // 로그인 버튼을 누른다.
     cy.contains('구글로 로그인하기').click(); // 로그인 버튼을 누른다.
 
     // cy.loginGoogleForDesktop();

--- a/frontend/cypress/e2e/mobile/login.cy.ts
+++ b/frontend/cypress/e2e/mobile/login.cy.ts
@@ -1,30 +1,24 @@
 describe('로그인 관련 로직을 테스트 한다.', () => {
-  beforeEach(() => {
+  it('로그인 - 로그아웃 테스트', () => {
     cy.viewport('iphone-5');
+    cy.visit('');
 
-    cy.visit('/restaurants/311?celebId=7', {
-      onBeforeLoad: (win: any) => {
-        win.ontouchstart = true;
-      },
-    });
+    /** 로그인에 성공하면 마이페이지에 접근할 수 있다. */
+    cy.get('nav').find('button').last().click();
+    cy.get('#root').should('contain.text', '비회원으로 이용하기');
+    cy.get('#root').should('contain.text', '카카오로 로그인하기');
+    cy.get('#root').should('contain.text', '구글로 로그인하기');
+    cy.get('button[type="google"]').click();
+    cy.wait(5000);
 
-    cy.get('nav').find('button').last().click(); // 모바일 nav 하단의 마이 페이지 버튼을 누른다.
-    cy.get('button[type="google"]').click(); // 구글 로그인 하기 버튼을 누른다.
+    cy.get('nav').find('button').last().click();
+    cy.get('#root').should('contain.text', '로그아웃');
+
+    /** 로그아웃이 되었다면 프로필 버튼 클릭시 로그인 페이지로 이동한다. */
+    cy.contains('로그아웃').click();
+    cy.get('nav').find('button').last().click();
+    cy.get('#root').should('contain.text', '비회원으로 이용하기');
+    cy.get('#root').should('contain.text', '카카오로 로그인하기');
+    cy.get('#root').should('contain.text', '구글로 로그인하기');
   });
-
-  it('모바일에서 성시경, 소문난성수감자탕 페이지에서 로그인을 한 후 다시 성시경, 소문난성수감자탕 페이지로 돌아 간다.', () => {
-    // cy.location().should(loc => {
-    //   expect(loc.href).to.eq('http://localhost:3000/restaurants/311?celebId=7');
-    // });
-  });
-
-  // it('모바일에서 성시경, 소문난성수감자탕 페이지에서 로그인을 하고 회원 탈퇴 시 비회원 상태가 된다.', () => {
-  //   cy.get('nav').find('button').last().click(); // 모바일 nav 하단의 마이 페이지 버튼을 누른다.
-  //   cy.contains('회원탈퇴').click().wait(5000);
-  //   cy.get('button').contains('탈퇴하기').click();
-
-  //   cy.get('nav').find('button').last().click(); // 모바일 nav 하단의 마이 페이지 버튼을 누른다.
-
-  //   cy.contains('비회원으로 이용하기');
-  // });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -32,9 +32,9 @@ Cypress.Commands.add('loginGoogle', () => {
 });
 
 Cypress.Commands.add('loginGoogleForDesktop', () => {
-  cy.get('button[type="google"]').click(); // 구글 로그인 하기 버튼을 누른다.
-
-  cy.loginGoogle();
+  cy.getByAriaLabel('프로필').click();
+  cy.getByAriaLabel('로그인').click();
+  cy.contains('구글로 로그인하기').click();
 });
 
 Cypress.Commands.add('loginGoogleForMobile', () => {

--- a/frontend/src/components/@common/InfoButton/InfoButton.tsx
+++ b/frontend/src/components/@common/InfoButton/InfoButton.tsx
@@ -15,7 +15,7 @@ interface InfoButtonProps {
 
 function InfoButton({ isShow = false, isSuccess, profile }: InfoButtonProps) {
   return (
-    <StyledInfoButton isShow={isShow} aria-hidden>
+    <StyledInfoButton isShow={isShow} aria-label="프로필">
       <Menu />
       {isSuccess ? <ProfileImage name={profile.nickname} imageUrl={profile.profileImageUrl} size="30px" /> : <User />}
     </StyledInfoButton>

--- a/frontend/src/components/BottomNavBar/BottomNavBar.tsx
+++ b/frontend/src/components/BottomNavBar/BottomNavBar.tsx
@@ -2,16 +2,14 @@ import { useRef } from 'react';
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { shallow } from 'zustand/shallow';
-import { useQuery } from '@tanstack/react-query';
 import HomeIcon from '~/assets/icons/home.svg';
 import UserIcon from '~/assets/icons/user.svg';
 import MapIcon from '~/assets/icons/navmap.svg';
 import HeartIcon from '~/assets/icons/navbar-heart.svg';
 import useScrollBlock from '~/hooks/useScrollBlock';
 import useBottomNavBarState from '~/hooks/store/useBottomNavBarState';
-import { ProfileData } from '~/@types/api.types';
-import { getProfile } from '~/api/user';
 import useNavigateSignUp from '~/hooks/useNavigateSignUp';
+import useCheckLogin from '~/hooks/server/useCheckLogin';
 
 interface BottomNavBarProps {
   isHide: boolean;
@@ -32,10 +30,7 @@ function BottomNavBar({ isHide }: BottomNavBarProps) {
     shallow,
   );
 
-  const { isSuccess: isLogin } = useQuery<ProfileData>({
-    queryKey: ['profile'],
-    queryFn: () => getProfile(),
-  });
+  const { isSuccess: isLogin } = useCheckLogin();
 
   const clickHome = () => {
     setHomeSelected();

--- a/frontend/src/components/InfoDropDown/InfoDropDown.tsx
+++ b/frontend/src/components/InfoDropDown/InfoDropDown.tsx
@@ -54,7 +54,7 @@ function InfoDropDown() {
           ) : (
             <Modal.OpenButton modalTitle="로그인 및 회원가입" isCustom modalContent={<LoginModal />}>
               <DropDown.Option isCustom>
-                <StyledDropDownOption>로그인</StyledDropDownOption>
+                <StyledDropDownOption aria-label="로그인">로그인</StyledDropDownOption>
               </DropDown.Option>
             </Modal.OpenButton>
           )}

--- a/frontend/src/components/InfoDropDown/InfoDropDown.tsx
+++ b/frontend/src/components/InfoDropDown/InfoDropDown.tsx
@@ -38,7 +38,7 @@ function InfoDropDown() {
         </StyledTriggerWrapper>
       </DropDown.Trigger>
       <DropDown.Options as="ul" isCustom>
-        <StyledDropDownWrapper>
+        <StyledDropDownWrapper data-cy="dropdown">
           {isLogin ? (
             <>
               <DropDown.Option as="li" isCustom onClick={goMyPage}>

--- a/frontend/src/components/RestaurantDetailLikeButton/RestaurantDetailLikeButton.tsx
+++ b/frontend/src/components/RestaurantDetailLikeButton/RestaurantDetailLikeButton.tsx
@@ -24,7 +24,7 @@ function RestaurantDetailLikeButton({ showText = true, restaurantId, celebId }: 
   return (
     <button type="button" onClick={toggleRestaurantLike}>
       <WhiteLove width={30} {...(isLiked && { fill: '#fff' })} />
-      {showText && <div>위시리스트에서 삭제하기</div>}
+      {showText && <div>위시리스트</div>}
     </button>
   );
 }

--- a/frontend/src/hooks/context/ReviewModalProvider.tsx
+++ b/frontend/src/hooks/context/ReviewModalProvider.tsx
@@ -24,7 +24,7 @@ interface ReviewModalProviderProps {
 }
 
 function ReviewModalProvider({ children }: ReviewModalProviderProps) {
-  const { isLogin } = useCheckLogin();
+  const { isSuccess: isLogin } = useCheckLogin();
 
   const [formType, setFormType] = useState<ReviewFormType>(null);
   const [reviewId, setReviewId] = useState(null);

--- a/frontend/src/hooks/server/useCheckLogin.ts
+++ b/frontend/src/hooks/server/useCheckLogin.ts
@@ -3,15 +3,10 @@ import { getProfile } from '~/api/user';
 
 import type { ProfileData } from '~/@types/api.types';
 
-const useCheckLogin = () => {
-  const { data } = useQuery<ProfileData>({
+const useCheckLogin = () =>
+  useQuery<ProfileData>({
     queryKey: ['profile'],
     queryFn: getProfile,
   });
-
-  return {
-    isLogin: Boolean(data),
-  };
-};
 
 export default useCheckLogin;

--- a/frontend/src/pages/WishListPage.tsx
+++ b/frontend/src/pages/WishListPage.tsx
@@ -66,7 +66,7 @@ const StyledResultCount = styled.span`
   font-size: ${FONT_SIZE.md};
 `;
 
-const StyledResultSection = styled.div`
+const StyledResultSection = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;


### PR DESCRIPTION
## ✨ 요약
```
cypress 에러 수정 및 e2e 테스트 코드 추가작성하였습니다.
```

## 작성한 E2E 테스트

### 좋아요 관련 기능을 테스트 한다.

https://github.com/woowacourse-teams/2023-celuveat/assets/102432453/9eecedec-cc4f-40c0-9fe6-df462624e6c6

### 로그인 관련 로직을 테스트 한다.

- 모바일

https://github.com/woowacourse-teams/2023-celuveat/assets/102432453/1506abb9-2310-4e73-8b20-0aa54e55eb53

- 데스크탑

https://github.com/woowacourse-teams/2023-celuveat/assets/102432453/fb0876b8-2e89-4d33-bf15-79eaaae860c3

추가적으로 `getProfile` 요청의 경우 훅이 있음에도 재사용되지 않아 공통된 로직에 훅을 적용하였습니다.

<br><br>

## 😎 해결한 이슈
- close #700 

<br><br>
